### PR TITLE
Remove unnecessary timestampsInSnapshots setting

### DIFF
--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -114,9 +114,6 @@ export default class App extends Component {
 		};
 		this.prefs = {};
 
-		const firestore = firebase.firestore();
-		const settings = {timestampsInSnapshots: true};
-		firestore.settings(settings);
 		firebase.auth().onAuthStateChanged(user => {
 			this.setState({ isLoginModalOpen: false });
 			if (user) {

--- a/src/db.js
+++ b/src/db.js
@@ -56,7 +56,6 @@ import { log } from './utils';
 				return resolve(db);
 			}
 			const store = firebase.firestore();
-			store.settings({ timestampsInSnapshots: true });
 			return store
 				.enablePersistence({ experimentalTabSynchronization: true })
 				.then(function() {


### PR DESCRIPTION
The timestampsInSnapshots setting now defaults to true and you no
longer need to explicitly set it. In a future release, the setting
will be removed entirely