### PR TITLE
feat: introduce embed mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
 	"dependencies": {
 		"@emmetio/codemirror-plugin": "^1.1.3",
 		"@zenuml/core": "^3.14.5",
+		"clsx": "^2.0.0",
 		"code-blast-codemirror": "chinchang/code-blast-codemirror#web-maker",
 		"codemirror": "^5.65.16",
 		"dom-to-image": "github:MichalBryxi/dom-to-image",

--- a/src/assets/external-link.svg
+++ b/src/assets/external-link.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-external-link" width="24" height="24"
+  viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" color="#333" stroke-linecap="round"
+  stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+  <path d="M12 6h-6a2 2 0 0 0 -2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-6" />
+  <path d="M11 13l9 -9" />
+  <path d="M15 4h5v5" />
+</svg>

--- a/src/components/EmbedHeader.jsx
+++ b/src/components/EmbedHeader.jsx
@@ -1,0 +1,22 @@
+export default function EmbedHeader(props) {
+	return (
+		<div className="embed-header">
+			<div className="embed-header__left">
+				<div className="header-logo">
+					<img src="assets/zenuml-icon.png" alt="zenuml logo" />
+				</div>
+				<div className="tit">{this.props.title || 'Untitled'}</div>
+			</div>
+			<div className="embed-header__right">
+				<a
+					className="embed-header__external"
+					title="Edit on app.zenuml.com"
+					target="_blank"
+					href={this.props.link}
+				>
+					<img src="assets/external-link.svg" alt="link logo" />
+				</a>
+			</div>
+		</div>
+	);
+}

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -5,7 +5,7 @@ import Tab from './Tab';
 class Tabs extends Component {
 	static propTypes = {
 		children: PropTypes.instanceOf(Array).isRequired,
-	}
+	};
 
 	constructor(props) {
 		super(props);
@@ -16,17 +16,17 @@ class Tabs extends Component {
 		this.state = {
 			activeTab: this.props.children[0].props.label,
 		};
-	}
+	};
 	onClickTabItem = async (tab) => {
-		await this.setState({activeTab: tab});
+		await this.setState({ activeTab: tab });
 		this.props.onChange(tab);
-	}
+	};
 
 	static modifyChildren(child, visible) {
 		const className = [child.props.className, visible ? '' : 'hide'].join(' ');
 
 		const props = {
-			className
+			className,
 		};
 
 		return React.cloneElement(child, props);
@@ -34,18 +34,14 @@ class Tabs extends Component {
 	render() {
 		const {
 			onClickTabItem,
-			props: {
-				children,
-			},
-			state: {
-				activeTab,
-			}
+			props: { children },
+			state: { activeTab },
 		} = this;
 		return (
 			<div className="tabs" style="height:100%">
 				<ol className="tab-list editor-nav">
 					{children.map((child) => {
-						const { label,lineOfCode } = child.props;
+						const { label, lineOfCode } = child.props;
 						return (
 							<Tab
 								activeTab={activeTab}
@@ -57,16 +53,15 @@ class Tabs extends Component {
 						);
 					})}
 				</ol>
-				<div className="tab-content" style="height: calc(100% - 45px); overflow-y:auto;-webkit-overflow-scrolling: touch;">
-					{
-						React.Children.map(children,
-							(child) => {
-								if (child.props.label !== activeTab) {
-									return React.Children.map(child.props.children, c => Tabs.modifyChildren(c, false));
-								}
-								return child.props.children;
-							})
-					}
+				<div className="tab-content">
+					{React.Children.map(children, (child) => {
+						if (child.props.label !== activeTab) {
+							return React.Children.map(child.props.children, (c) =>
+								Tabs.modifyChildren(c, false)
+							);
+						}
+						return child.props.children;
+					})}
 				</div>
 			</div>
 		);

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -1384,6 +1384,8 @@ BookLibService.Borrow(id) {
 	}
 
 	render() {
+		// remove field imageBase64 from currentItem and save it to a local variable as a copy
+		const { imageBase64, ...currentItem } = this.state.currentItem;
 		return (
 			<div>
 				<div class={clsx('main-container', this.isEmbed && 'embed-app')}>
@@ -1411,7 +1413,7 @@ BookLibService.Borrow(id) {
 							title={this.searchParams.get('title')}
 							link={
 								`/?code=${JSON.stringify(
-									this.state.currentItem || ''
+										currentItem
 								)}&title=${this.searchParams.get('title')}` || ''
 							}
 						/>

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -110,7 +110,7 @@ export default class App extends Component {
 			lightVersion: false,
 			lineWrap: true,
 			infiniteLoopTimeout: 1000,
-			layoutMode: 2,
+			layoutMode: 1,
 			isJs13kModeOn: false,
 			autoCloseTags: true,
 		};
@@ -192,8 +192,16 @@ export default class App extends Component {
 			(result) => {
 				this.toggleLayout(result.layoutMode);
 				this.state.prefs.layoutMode = result.layoutMode;
-				if (result.code) {
-					lastCode = result.code;
+				let urlCode;
+				try {
+					urlCode = JSON.parse(
+						decodeURIComponent(new URLSearchParams(location.search).get('code'))
+					);
+				} catch (err) {
+					console.error(err);
+				}
+				if (urlCode || result.code) {
+					lastCode = urlCode || result.code;
 				}
 			}
 		);

--- a/src/computes.js
+++ b/src/computes.js
@@ -178,9 +178,13 @@ export function computeJs(
 		const cursor = e.data && e.data.cursor;
 
 	  if (code && app) {
-		  app.render(code, { enableMultiTheme: false, onContentChange: (code) => {
-		  	window.parent.postMessage({ code })
-		  }});
+		  app.render(code, {
+				enableMultiTheme: false,
+				onContentChange: (code) => {
+					window.parent.postMessage({ code })
+				},
+				stickyOffset: Number(new URLSearchParams(window.location.search).get('stickyOffset') || 0)
+			});
 	  }
 
 	  if(app && (cursor !== null || cursor !== undefined)) {

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap");
+@import url('https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap');
 
 :root {
 	--color-text: #d4cde9;
@@ -23,7 +23,7 @@ body {
 	font-size: 87.5%;
 	/* speocifically for mobile when keyboard is open */
 	position: relative;
-	font-family: "Ubuntu", sans-serif;
+	font-family: 'Ubuntu', sans-serif;
 	/* font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial,
 		sans-serif, 'Segoe UI Emoji', 'Segoe UI Symbol'; */
 }
@@ -46,7 +46,7 @@ textarea {
 	box-sizing: border-box;
 }
 
-[role="button"] {
+[role='button'] {
 	cursor: pointer;
 }
 
@@ -207,7 +207,7 @@ label {
 	cursor: pointer;
 }
 
-[class*="hint--"]:after {
+[class*='hint--']:after {
 	text-transform: none;
 	font-weight: normal;
 	letter-spacing: 0.5px;
@@ -323,7 +323,7 @@ a > svg {
 }
 
 .star:after {
-	content: "★";
+	content: '★';
 	color: currentColor;
 }
 
@@ -637,6 +637,7 @@ body > #demo-frame {
 }
 
 .main-header,
+.embed-header,
 .footer {
 	padding: 0.5rem 1rem;
 	background-color: rgb(18, 19, 27);
@@ -658,6 +659,30 @@ body > #demo-frame {
 	align-items: center;
 	border: 0;
 	border-bottom: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.embed-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	color: #333;
+	background-color: #fff;
+	border-bottom: 1px solid #dadde1;
+}
+
+.embed-header__left {
+	display: flex;
+	align-items: center;
+}
+
+.embed-header__external {
+	opacity: 0.6;
+}
+.embed-header__external:hover {
+	opacity: 1;
+}
+.embed-header__external:focus {
+	outline: none;
 }
 
 .btn--dark > svg {
@@ -1602,7 +1627,7 @@ body:not(.is-app) .show-when-app {
 }
 
 .onboard-selection.selected:after {
-	content: "";
+	content: '';
 	position: absolute;
 	right: -20px;
 	bottom: 40px;
@@ -1807,6 +1832,12 @@ while the theme CSS file is loading */
 	grid-template-columns: 1fr 1fr 1fr;
 	padding: 0;
 	margin: 0;
+}
+
+.tab-content {
+	height: calc(100% - 45px);
+	overflow-y: auto;
+	-webkit-overflow-scrolling: touch;
 }
 
 .tab-list-item {
@@ -2027,7 +2058,7 @@ ol.editor-nav li {
 }
 
 .popover-backdrop {
-	content: "";
+	content: '';
 	position: fixed;
 	top: 0;
 	left: 0;
@@ -2203,4 +2234,24 @@ ol.editor-nav li {
 	object-position: left top;
 	width: 300%;
 	height: 300%;
+}
+
+.embed-app .toolbox {
+	display: none;
+}
+
+.embed-app .tab-list {
+	display: none;
+}
+
+.embed-app .promotion {
+	display: none;
+}
+
+.embed-app .content-wrap {
+	max-height: none;
+}
+
+.embed-app .tab-content {
+	height: 100%;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4567,6 +4567,11 @@ cloneable-readable@^1.0.0:
     process-nextick-args "^2.0.0"
     readable-stream "^2.3.5"
 
+clsx@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.0.0.tgz#12658f3fd98fafe62075595a5c30e43d18f3d00b"
+  integrity sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"


### PR DESCRIPTION
To use app.zenuml.com as an embedded editor on zenuml.com, it needs to be made able to get the code from the URL.

This presents a temporary solution, we can use a diagram-id to render a certain diagram in future.

Besides, I noticed that the default layoutMode is currently set to mode2. I fix it to mode1.