### PR TITLE
Fix reload different diagram issue by removing image blob generation in saveCode

### DIFF
--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -743,9 +743,6 @@ BookLibService.Borrow(id) {
 	}
 
 	async saveCode(key) {
-		const imageBlob = await this.contentWrap.getPngBlob();
-
-		this.state.currentItem.imageBase64 = await blobToBase64(imageBlob);
 		this.state.currentItem.updatedOn = Date.now();
 		this.state.currentItem.layoutMode = this.state.currentLayoutMode;
 
@@ -769,7 +766,9 @@ BookLibService.Borrow(id) {
 
 		try {
 			const result = await syncDiagram(this.state.currentItem);
-			this.state.currentItem.shareLink = getShareLink(result);
+			if(result) {
+				this.state.currentItem.shareLink = getShareLink(result);
+			}
 		} catch (e) {
 			console.error(e);
 		}

--- a/src/services/syncService.js
+++ b/src/services/syncService.js
@@ -1,6 +1,11 @@
 import firebase from 'firebase/app';
 
 async function syncDiagram(currentItem) {
+	if(location.host === 'localhost:8080') {
+		console.log('!! Skipping sync-diagram call in local environment');
+		return;
+	}
+
 	const { id, title, js, imageBase64 } = currentItem;
 	if (!js || !title || !imageBase64) {
 		throw Error('Cannot sync diagram because of missing data');


### PR DESCRIPTION
The code `await this.contentWrap.getPngBlob()` in `saveCode` causes the reloading wrong diagram issue. But the reason is not clear.