### PR TITLE
Fix: restore SplitPane gutter position preservation

### DIFF
--- a/src/components/SplitPane.jsx
+++ b/src/components/SplitPane.jsx
@@ -11,18 +11,18 @@ export class SplitPane extends Component {
   componentDidMount() {
     this.updateSplit();
   }
-  componentWillUpdate() {
-    if (this.splitInstance) {
-      try {
-        this.splitInstance.destroy();
-      } catch (e) {
-        // Ignore errors during destruction (e.g. if nodes are already removed)
-        // This happens often with VDOM re-renders conflicting with Split.js DOM manipulation
+  componentDidUpdate(prevProps) {
+    if (prevProps.direction !== this.props.direction) {
+      if (this.splitInstance) {
+        try {
+          this.splitInstance.destroy();
+        } catch (e) {
+          // Ignore errors during destruction (e.g. if nodes are already removed)
+          // This happens often with VDOM re-renders conflicting with Split.js DOM manipulation
+        }
       }
+      this.updateSplit();
     }
-  }
-  componentDidUpdate() {
-    this.updateSplit();
   }
   componentWillUnmount() {
     if (this.splitInstance) {


### PR DESCRIPTION
## Problem
During the merge conflict resolution in PR #784, commit `1923579` was accidentally reverted. This caused the split gutter position to reset on every code change.

## Root Cause
The merge took master's `componentWillUpdate()` approach which destroys the split on every update, then I added `componentDidUpdate()` to recreate it. But this missed the `prevProps.direction` check from the original commit.

## Fix
- Remove `componentWillUpdate()` that destroyed split on every update
- Use `componentDidUpdate(prevProps)` with direction check
- Only rebuild split when `direction` prop actually changes
- This preserves the gutter position when code changes

## Testing
1. Open the app and drag the splitter to a custom position
2. Make code changes in the editor
3. Verify the gutter position is preserved (not reset)