### PR TITLE
fix: deployed diagram doesn't render — @zenuml/core UMD baked a dev-only /@fs/ path

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -34,6 +34,16 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
       - run: pnpm install --no-frozen-lockfile && pnpm build
+      # Pre-deploy guard: serve the built dist statically and verify the diagram
+      # renders. Catches deploy-only bundling bugs (e.g. a dev-only /@fs/ asset
+      # path) that the dev-server suite can't see, BEFORE anything ships to
+      # staging. Runs on PRs too. See e2e/tests/production-build.spec.js.
+      - name: Install Playwright (chromium)
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Verify production build renders
+        env:
+          PW_PROD_BUILD: '1'
+        run: pnpm exec playwright test production-build --project=chromium
       - run: pnpm release
       - name: Setup Firebase service account
         run: echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT_STAGING }}' > /tmp/gcp-key.json

--- a/docs/adr/0001-release-pipeline-imitating-conf-app.md
+++ b/docs/adr/0001-release-pipeline-imitating-conf-app.md
@@ -42,6 +42,16 @@ Priority is **safety/reliability over convenience**, but we adopt both.
    smoke (`app.zenuml.com`). The suite is entirely client-side / localStorage,
    so it is safe to run against prod (no server state mutated).
 
+1b. **Pre-deploy build-render guard.** Before deploying, the build job serves the
+   built `dist/` statically (`PW_PROD_BUILD=1`, a plain static server on a
+   dedicated port) and runs `e2e/tests/production-build.spec.js`. The dev server
+   transparently serves Vite `/@fs/<abs>` URLs, so deploy-only bundling bugs
+   (e.g. an asset shim baking a dev-only path) are invisible to the dev-server
+   suite and only surface once served statically. This guard runs on PRs too, so
+   the bug class is caught at PR time — not just by the post-deploy gate. (The
+   pipeline's first real run caught exactly such a bug: the `@zenuml/core` UMD
+   shim emitted a `/@fs/` path that 404'd on staging; fixed in `vite.config.js`.)
+
 2. **Staging E2E is a hard gate.** On push to `master`: deploy staging → run the
    full suite against `staging.zenuml.com`. A red gate blocks release creation.
    The deployed-URL run is **chromium-only**: verified against live staging,

--- a/e2e/tests/production-build.spec.js
+++ b/e2e/tests/production-build.spec.js
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test';
+
+// Regression guard for a deploy-only class of bug: the @zenuml/core UMD bundle
+// was referenced from a Vite dev-only `/@fs/<abs path>` URL (see the
+// zenuml-core-asset-url-shim in vite.config.js). That URL works under `pnpm dev`
+// (the dev server serves /@fs/) but 404s in any deployed/static build, so the
+// diagram silently fails to render in production while every dev-server test
+// stays green.
+//
+// This suite must run against the STATIC production build, not the dev server:
+//
+//   pnpm build && PW_PROD_BUILD=1 pnpm exec playwright test production-build
+//
+// PW_PROD_BUILD=1 makes playwright.config serve `dist/` with a plain static
+// server, which 404s /@fs/ paths exactly like Firebase Hosting.
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('loginAndsaveMessageSeen', 'true');
+  });
+});
+
+test('built app requests no dev-only /@fs/ asset path', async ({ page }) => {
+  const fsFailures = [];
+  page.on('response', (r) => {
+    if (r.url().includes('/@fs/') && r.status() >= 400) {
+      fsFailures.push(`${r.status()} ${r.url()}`);
+    }
+  });
+  page.on('requestfailed', (r) => {
+    if (r.url().includes('/@fs/')) fsFailures.push(`failed ${r.url()}`);
+  });
+
+  await page.goto('/');
+  // Give the preview iframe time to request its bundle.
+  await page.waitForTimeout(3000);
+
+  expect(
+    fsFailures,
+    `Built app must not depend on dev-only /@fs/ paths (they 404 once deployed):\n${fsFailures.join('\n')}`,
+  ).toEqual([]);
+});
+
+test('built app renders the @zenuml/core diagram (SVG)', async ({ page }) => {
+  await page.goto('/');
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(
+          () =>
+            !!document.getElementById('demo-frame')?.contentDocument?.querySelector('svg'),
+        ),
+      { timeout: 15_000 },
+    )
+    .toBe(true);
+});
+
+test('built app loads the @zenuml/core UMD bundle into the iframe', async ({ page }) => {
+  await page.goto('/');
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(
+          () => typeof document.getElementById('demo-frame')?.contentWindow?.zenuml,
+        ),
+      { timeout: 15_000 },
+    )
+    .not.toBe('undefined');
+});

--- a/e2e/tests/smoke.spec.js
+++ b/e2e/tests/smoke.spec.js
@@ -2,6 +2,30 @@ import { test, expect } from '@playwright/test';
 
 const SAVE_KEY = process.platform === 'darwin' ? 'Meta+s' : 'Control+s';
 
+// Deployed sites load third-party analytics/CDN scripts (Google Tag Manager,
+// Cloudflare Zaraz, Clarity, Paddle) that throw their own uncaught errors we
+// neither own nor can fix. Against staging/prod they would otherwise fail every
+// test via the pageerror handler. Errors whose source matches one of these is
+// treated as noise; genuine app errors still fail the test.
+const THIRD_PARTY_ERROR_SOURCES = [
+  'userscript.js', // Cloudflare Zaraz wraps third-party tools in userscript.js
+  'gtm.js',
+  'googletagmanager',
+  'google-analytics',
+  'analytics.js',
+  'clarity.js',
+  'clarity.ms',
+  'paddle.js',
+  'cdn.paddle.com',
+  'zaraz',
+  'cloudflareinsights',
+];
+
+function isThirdPartyError(err) {
+  const haystack = `${err?.message || ''}\n${err?.stack || ''}`;
+  return THIRD_PARTY_ERROR_SOURCES.some((src) => haystack.includes(src));
+}
+
 test.beforeEach(async ({ page }) => {
   // Suppress the first-save confirm() dialog that fires for unsigned-in users.
   // See src/components/app.jsx:845 — the dialog blocks headless runs.
@@ -9,8 +33,10 @@ test.beforeEach(async ({ page }) => {
     window.localStorage.setItem('loginAndsaveMessageSeen', 'true');
   });
 
-  // Surface uncaught page errors as test failures.
+  // Surface uncaught page errors as test failures — except known third-party
+  // analytics/CDN noise, which we don't own (see THIRD_PARTY_ERROR_SOURCES).
   page.on('pageerror', (err) => {
+    if (isThirdPartyError(err)) return;
     throw err;
   });
 

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -4,8 +4,38 @@ import { defineConfig, devices } from '@playwright/test';
 // the deployed staging site (the post-staging-deploy gate), or production
 // (the post-prod-deploy smoke). When it points at a remote URL we must NOT
 // spin up the local dev server. See docs/adr/0001-release-pipeline-imitating-conf-app.md.
-const baseURL = process.env.PW_BASE_URL || 'http://localhost:3000';
 const isRemoteTarget = !!process.env.PW_BASE_URL;
+const isProdBuild = process.env.PW_PROD_BUILD === '1';
+
+// Prod-build mode uses a dedicated port so it never collides with a dev server
+// that may already be running on 3000.
+const PROD_BUILD_PORT = 3100;
+const baseURL =
+  process.env.PW_BASE_URL ||
+  (isProdBuild ? `http://localhost:${PROD_BUILD_PORT}` : 'http://localhost:3000');
+
+// PW_PROD_BUILD=1 serves the *built* `dist/` with a plain static server instead
+// of the dev server. The dev server transparently serves Vite `/@fs/<abs>` URLs,
+// which hides deploy-only bundling bugs (e.g. an asset shim that bakes a dev-only
+// `/@fs/` path). A static server rooted at `dist/` 404s such paths exactly like
+// Firebase Hosting does. Requires `dist/` to be built first (`pnpm build`).
+function resolveWebServer() {
+  if (isRemoteTarget) return undefined; // site already live
+  if (isProdBuild) {
+    return {
+      command: `npx http-server ./dist -p ${PROD_BUILD_PORT} -s -c-1`,
+      url: `http://localhost:${PROD_BUILD_PORT}`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120 * 1000,
+    };
+  }
+  return {
+    command: 'pnpm dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  };
+}
 
 export default defineConfig({
   testDir: './e2e/tests',
@@ -36,14 +66,6 @@ export default defineConfig({
     },
   ],
 
-  // Only start a local dev server when testing locally. Against a deployed
-  // URL (PW_BASE_URL set) the site is already live, so skip it entirely.
-  webServer: isRemoteTarget
-    ? undefined
-    : {
-        command: 'pnpm dev',
-        url: 'http://localhost:3000',
-        reuseExistingServer: !process.env.CI,
-        timeout: 120 * 1000,
-      },
+  // Local dev server, static production-build server, or nothing (remote URL).
+  webServer: resolveWebServer(),
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,7 @@ import legacy from '@vitejs/plugin-legacy';
 import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
+import { readFileSync } from 'fs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -18,10 +19,21 @@ function getCommitHash() {
 // @zenuml/core's package.json `exports` only exposes the root entry, so
 // `import '@zenuml/core/dist/zenuml?url'` in src/utils.js is rejected by both
 // node-style resolution and Vite's alias + dep-optimizer pipeline. This plugin
-// intercepts that one specifier and returns the file's @fs URL directly.
+// intercepts that one specifier and resolves it to the bundle's URL.
+//
+// Dev (serve) and build must differ:
+//   - serve: return Vite's `/@fs/<abs>` URL — the dev server streams the file.
+//   - build: a `/@fs/<abs>` URL is dev-server-only and 404s once the build is
+//     served statically (Firebase Hosting), so the diagram never renders. We
+//     must emit the file as a real hashed asset and reference it by its built
+//     URL. Guarded by e2e/tests/production-build.spec.js.
+let zenumlShimIsBuild = false;
 const zenumlAssetUrlShim = {
   name: 'zenuml-core-asset-url-shim',
   enforce: 'pre',
+  configResolved(config) {
+    zenumlShimIsBuild = config.command === 'build';
+  },
   resolveId(source) {
     if (source === '@zenuml/core/dist/zenuml?url') {
       return '\0zenuml-core-asset-url';
@@ -34,6 +46,14 @@ const zenumlAssetUrlShim = {
         __dirname,
         'node_modules/@zenuml/core/dist/zenuml.js',
       );
+      if (zenumlShimIsBuild) {
+        const referenceId = this.emitFile({
+          type: 'asset',
+          name: 'zenuml.js',
+          source: readFileSync(filePath),
+        });
+        return `export default import.meta.ROLLUP_FILE_URL_${referenceId};`;
+      }
       return `export default ${JSON.stringify('/@fs' + filePath)};`;
     }
     return null;


### PR DESCRIPTION
## What & why
The release pipeline's first real run (PR #791) caught that the **deployed diagram does not render**: the freshly-deployed staging app loads the `@zenuml/core` UMD bundle from a Vite **dev-server-only** `/@fs/<abs path>` URL, baked into the production bundle. On a static/deployed host (Firebase) that path 404s → CodeMirror loads but no SVG.

```
404  https://staging.zenuml.com/@fs/home/runner/work/web-sequence/.../@zenuml/core/dist/zenuml.js
```

Root cause: `vite.config.js` `zenuml-core-asset-url-shim` returned `'/@fs' + absPath` for **both** dev and build. `/@fs` only works under `pnpm dev`.

## Reproduced first (TDD)
Added `e2e/tests/production-build.spec.js` + a `PW_PROD_BUILD=1` mode in `playwright.config.js` that serves the built `dist/` with a plain static server (404s `/@fs/` exactly like Firebase). Against the broken build: **3 failed**. After the fix: **3 passed**.

## Fixes (both)
1. **Vite shim** — branch on `config.command`: keep `/@fs` for dev (serve), but in build `emitFile` the bundle as a real hashed asset (`import.meta.ROLLUP_FILE_URL_*`). Built output now references `/assets/zenuml-<hash>.js` (a real file); no `/@fs` anywhere in `dist/`.
2. **Gate robustness** — the smoke spec's `pageerror` handler rethrew third-party Cloudflare-Zaraz/GTM/Clarity/Paddle `userscript.js` errors, which would fail every deployed-URL run on noise we don't own. Now filtered to app-origin errors only.

## Prevention
Wired the prod-build e2e as a **pre-deploy guard** in `deploy-staging.yml` (`build` job): serves the built dist and verifies render **before** anything deploys — on PRs too. A broken bundle can no longer reach staging.

## Verification (local, chromium)
- Reproduction: **red → green** (3 failed on broken build → 3 passed on fixed build).
- Full suite vs fixed static build (`PW_PROD_BUILD=1`): **34 passed, 1 pre-existing flaky** (Escape-cheatsheet, recovers on retry).
- Dev mode unregressed: `@smoke` 3 passed against `pnpm dev`.
- Build under Node 22 emits `dist/assets/zenuml-<hash>.js`; `grep /@fs dist/` → none.

Not locally verifiable: live CI Actions run (will exercise the new pre-deploy guard on this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)