### PR TITLE
chore(skills): spot-check workflow and branch/release agent skills

### DIFF
--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: babysit-pr
+description: Monitor and diagnose GitHub Actions checks on ZenUML web-sequence PRs, fixing code-caused CI failures when appropriate. Use when the user says "babysit PR", "check PR status", "fix CI", "why is CI red", "watch this PR", or a PR is blocked by build, release, Firebase deploy, artifact, lint, test, or runner failures.
+---
+
+# Babysit PR
+
+Watch a web-sequence PR, diagnose failures, optionally fix code issues, and retry within a small budget.
+
+## Scope
+
+- Repository: `ZenUml/web-sequence`
+- Main PR workflow: `Deploy to Stage`
+- Base branch: `master`
+- Production workflow `Deploy to Prod` runs only when a GitHub release is published.
+
+## Step 1. Find The PR
+
+Use the explicit PR number if provided. Otherwise infer from the current branch:
+
+```bash
+gh pr view --json number,title,url,headRefName,state,isDraft,statusCheckRollup
+```
+
+If no PR exists, stop and tell the user to use `submit-branch`.
+
+## Step 2. Check Status
+
+```bash
+gh pr checks <PR_NUMBER> --repo ZenUml/web-sequence
+gh pr view <PR_NUMBER> --repo ZenUml/web-sequence --json statusCheckRollup,headRefName,isDraft
+```
+
+Treat required successful checks as green. If checks are pending, find the latest run and watch it:
+
+```bash
+gh run list --repo ZenUml/web-sequence --branch <branch> --limit 5 --json databaseId,name,status,conclusion,event,createdAt
+gh run watch <RUN_ID> --repo ZenUml/web-sequence
+```
+
+## Step 3. Diagnose Failures
+
+Pull failed logs:
+
+```bash
+gh run view <RUN_ID> --repo ZenUml/web-sequence --log-failed
+```
+
+Classify the failure:
+
+- Build: Vite errors, missing imports, package resolution, `pnpm build`
+- Release packaging: `pnpm release`, gulp, extension artifact, zip creation
+- Firebase staging deploy: credentials, project config, deploy command, emulator/config mismatch
+- Functions config/deploy: failures under `functions/`
+- Test/lint: Jest, Playwright, ESLint
+- Dependency/install: pnpm lockfile or Node version issues
+- Runner/infra: network, cache, GitHub outage, transient Firebase error
+- Dependabot/secrets skip: staging deploy intentionally skipped for Dependabot actors
+
+## Step 4. Fix Or Rerun
+
+Before editing:
+
+```bash
+git fetch origin
+git checkout <PR_BRANCH>
+git pull --ff-only origin <PR_BRANCH>
+```
+
+Fix only failures with a local code cause. Do not patch around secrets, credentials, Firebase project access, or GitHub runner outages.
+
+Suggested local checks by category:
+
+- Build: `yarn build`
+- Release: `yarn build && yarn release`
+- Jest: `yarn test`
+- Playwright: `yarn test:e2e`
+- Lint: `yarn lint`
+- CI parity for package manager issues: `pnpm install && pnpm build`
+
+If a failure is clearly transient infra, rerun failed jobs:
+
+```bash
+gh run rerun <RUN_ID> --repo ZenUml/web-sequence --failed
+```
+
+## Step 5. Push And Watch
+
+After a code fix:
+
+```bash
+git add <specific-files>
+git commit -m "fix: <ci failure summary>"
+git push origin <PR_BRANCH>
+```
+
+Then watch the new run. Maximum retry budget: 3 total fix/rerun attempts. Re-diagnose from fresh logs after each attempt.
+
+## Safety Rules
+
+- Never force-push.
+- Never resolve merge conflicts automatically.
+- Never commit unrelated local changes.
+- Never treat Firebase secret/auth failures as code fixes.
+- If CI passes after rerun without code changes, report likely flakiness.
+
+## Report
+
+```text
+PR #<number> Babysit Report
+- Status: PASSED|FAILED after <n> attempts|PENDING
+- Workflow/run: <url>
+- Failures found: ...
+- Fixes applied: ...
+- Manual attention needed: ...
+```

--- a/.claude/skills/babysit-pr/agents/openai.yaml
+++ b/.claude/skills/babysit-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Babysit PR"
+  short_description: "Monitor and fix web-sequence PR CI failures."
+  default_prompt: "Babysit the current web-sequence PR and report CI status or fixes."

--- a/.claude/skills/land-pr/SKILL.md
+++ b/.claude/skills/land-pr/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: land-pr
+description: Merge a green ZenUML web-sequence PR into master and verify staging CI after merge. Use when the user says "land PR", "merge this", "merge", "land", or a PR is ready to merge. Does not publish a production GitHub release.
+---
+
+# Land PR
+
+Merge a green PR into `master` and verify the post-merge staging workflow.
+
+## What Merge Triggers
+
+The `Deploy to Stage` workflow runs on push and pull_request. On `master`, it builds, packages release artifacts, configures Firebase staging, deploys staging, and uploads the Chrome extension artifact.
+
+Production deploy is separate: publishing a GitHub release triggers `Deploy to Prod`.
+
+## Preconditions
+
+Resolve the PR number, then run:
+
+```bash
+gh pr view <PR_NUMBER> --repo ZenUml/web-sequence --json state,isDraft,mergeable,reviewDecision,statusCheckRollup,headRefName,baseRefName,url
+```
+
+Verify:
+
+- PR is open and targets `master`.
+- No requested changes are outstanding.
+- Branch is mergeable.
+- Required checks are green.
+
+If checks are not green, use `babysit-pr` or stop and report.
+
+## Merge
+
+Use the repo's allowed merge strategy instead of assuming squash:
+
+```bash
+MERGE_FLAG=$(gh api repos/ZenUml/web-sequence \
+  --jq 'if .allow_squash_merge and (.allow_merge_commit | not) and (.allow_rebase_merge | not) then "--squash"
+        elif .allow_rebase_merge and (.allow_merge_commit | not) and (.allow_squash_merge | not) then "--rebase"
+        else "--merge" end')
+
+gh pr merge <PR_NUMBER> --repo ZenUml/web-sequence --auto --delete-branch $MERGE_FLAG
+```
+
+If the user requested a specific merge method, use it only if GitHub allows it.
+
+## Wait For Merge
+
+Poll until merged:
+
+```bash
+gh pr view <PR_NUMBER> --repo ZenUml/web-sequence --json state,mergeCommit
+```
+
+If auto-merge remains armed but not merged, report what is blocking it.
+
+## Verify Master CI
+
+After merge:
+
+```bash
+gh run list --repo ZenUml/web-sequence --branch master --limit 5 --json databaseId,name,status,conclusion,createdAt,event
+gh run watch <RUN_ID> --repo ZenUml/web-sequence
+```
+
+Check the `Deploy to Stage` result. If it fails after merge, do not auto-revert. Report the run URL, failing job, and key log lines.
+
+## Output
+
+```text
+Land Report: PR #<number>
+- Merge: MERGED|BLOCKED|AUTO-MERGE ARMED
+- Merge commit: <sha>
+- Master staging CI: PASS|FAIL|PENDING
+- Production: not deployed; publish a GitHub release to trigger Deploy to Prod
+```
+
+## Does Not
+
+- Fix failing CI; use `babysit-pr`.
+- Create a PR; use `submit-branch`.
+- Publish production releases.

--- a/.claude/skills/land-pr/agents/openai.yaml
+++ b/.claude/skills/land-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Land PR"
+  short_description: "Merge a green web-sequence PR into master and verify staging."
+  default_prompt: "Land the web-sequence PR and verify post-merge staging CI."

--- a/.claude/skills/release-app/SKILL.md
+++ b/.claude/skills/release-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-app
-description: Release ZenUML web-sequence to production (app.zenuml.com) by pushing master and publishing a GitHub release. Use when the user says "release", "release app", "deploy to prod", "ship to production", or invokes /release-app. Does not merge PRs — use ship-branch first if there are pending changes on a feature branch.
+description: Release ZenUML web-sequence to production (app.zenuml.com) by publishing a GitHub release, wait for deploy-prod CI + @smoke, then run a release-delta spot check (spot-check skill Step 5.5). Use when the user says "release", "release app", "deploy to prod", "ship to production", or invokes /release-app. Does not merge PRs — use ship-branch first if there are pending changes on a feature branch.
 ---
 
 # Release App
@@ -77,16 +77,63 @@ gh run watch <run-id>
 
 Report the final run status. A successful run deploys the app and uploads `chrome-extension.zip` as a release asset.
 
-## Post-release Smoke Test
+### Step 5: Wait for deploy + CI smoke (mandatory)
 
-After CI turns green:
+After publish, monitor **both** jobs in `deploy-prod.yml`:
 
-1. Open https://app.zenuml.com in the browser.
-2. Confirm the diagram canvas loads and renders a simple diagram.
-3. Check the version label in the footer/header matches the release if visible.
-4. Report any console errors.
+```bash
+gh run list --workflow=deploy-prod.yml --limit 3
+gh run watch <run-id>
+```
 
-Use the Playwright MCP (`user-playwright`) for this — navigate to `https://app.zenuml.com`, take a screenshot, and check the console.
+The **`Post-deploy smoke (prod)`** job runs `@smoke` against `https://app.zenuml.com` (chromium). Do not skip waiting for it.
+
+### Step 5.5: Spot check (targeted coverage for **this** release)
+
+**Runs after Step 5 is green. Do not skip.**
+
+General workflow: **spot-check** skill.
+
+Release-specific: understand **what shipped** between the previous published release and this tag, then verify **those behaviors** on production (or staging if prod is blocked) — not “run every recipe blindly.”
+
+#### 1. Establish the release delta
+
+```bash
+gh release list --repo ZenUml/web-sequence --exclude-drafts --limit 5 --json tagName
+git fetch --tags
+git log <prev-published-tag>..<new-tag> --oneline
+```
+
+Read commits as product intent. For non-obvious subjects, `git show <sha>` before planning.
+
+**Mandatory triage table** (every commit in the range):
+
+| Category | Criteria | Plan action |
+|----------|----------|-------------|
+| `behavioral` | User-visible app, diagram, editor, extension packaging, Firebase rules/functions affecting UX | ≥1 `[ ]` assertion |
+| `instrumentation` | Analytics only | Optional Mixpanel assertion or skip with reason |
+| `infra/test/docs` | CI, tests, docs, skills only | `Skipped: …` |
+
+`Spot check: N/A` only if **every** commit is `infra/test/docs`. Output the triage table before the plan or N/A.
+
+#### 2. Write the spot check plan (before browser)
+
+Use the **spot-check** plan format. Target **`https://app.zenuml.com`** unless the release did not deploy.
+
+Map delta themes to methods (examples):
+
+| Themes in delta | Typical checks |
+|-----------------|----------------|
+| Diagram / `@zenuml/core` / `vite.config.js` | Edit DSL → SVG in `#demo-frame`; optional `dsl-spot-check` recipe on prod |
+| Editor / modals / multi-page | Smoke paths from `smoke.spec.js` relevant to changed UI |
+| Deploy / hosting only | `@smoke` on prod (likely already green in Step 5) + one manual DSL edit |
+| Chrome extension | Note: extension ships as release asset; web app spot check does not replace Web Store verification |
+
+#### 3. Execute
+
+Follow **spot-check** execution. `@smoke` passing in CI does **not** replace delta assertions you wrote.
+
+Record pass / fail / skipped per planned `[ ]` line.
 
 ## Report
 
@@ -94,8 +141,9 @@ Use the Playwright MCP (`user-playwright`) for this — navigate to `https://app
 Release Report: <tag>
 - Commits released: <N>
 - GitHub Release: <url>
-- CI run: <url> — PASS|FAIL|IN_PROGRESS
-- Production smoke: PASS|FAIL|SKIPPED
+- CI deploy: <url> — PASS|FAIL
+- CI @smoke (prod): PASS|FAIL
+- Spot check (delta): PASS|FAIL|N/A — <summary>
 - Chrome extension asset: uploaded|skipped
 ```
 

--- a/.claude/skills/ship-branch/SKILL.md
+++ b/.claude/skills/ship-branch/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: ship-branch
+description: Take the current ZenUML web-sequence branch from local validation through PR submission, green CI, and merge to master. Use when the user says "ship", "ship it", "ship this branch", "submit and merge", or wants the full branch-to-master workflow. Stops at first failure and does not deploy production.
+---
+
+# Ship Branch
+
+Orchestrate the complete branch-to-`master` path for web-sequence.
+
+## Flow
+
+```text
+validate-branch
+  -> submit-branch
+  -> babysit-pr
+  -> land-pr
+```
+
+Stop at the first failing step. Do not skip validation unless the user explicitly asks.
+
+## Steps
+
+### 1. Validate Locally
+
+Use `validate-branch`. If it reports FAIL, stop and fix locally. If it reports PARTIAL, decide whether the blocker is acceptable before proceeding; mention the risk to the user.
+
+### 2. Submit PR
+
+Use `submit-branch`. Create the PR against `master`. If a PR already exists, reuse it.
+
+### 3. Get CI Green
+
+Use `babysit-pr` on the PR. Let it monitor `Deploy to Stage`, fix code-caused failures, or report infra/secrets blockers. If it exhausts retries, stop.
+
+### 4. Merge
+
+Confirm with the user before merging unless they explicitly said "ship it" or "ship this branch". Then use `land-pr`.
+
+### 5. Report
+
+On success:
+
+```text
+Ship Report: <branch>
+- Validation: PASS
+- PR: #<number> <url>
+- CI: GREEN
+- Merge: MERGED into master (<sha>)
+- Staging: verified by Deploy to Stage
+- Production: not deployed; publish a GitHub release when ready
+```
+
+On failure:
+
+```text
+Ship Report: <branch>
+- Stopped at: <validate|submit|ci|merge|post-merge-ci>
+- Status: FAIL|PARTIAL|BLOCKED
+- Details: ...
+- Next step: ...
+```
+
+## Rules
+
+- Never force-push.
+- Never commit unrelated local files.
+- Never merge with red required checks.
+- Never publish a production release as part of this skill.
+- Treat Firebase credential/deploy failures as manual attention unless logs prove a code/config cause.

--- a/.claude/skills/ship-branch/SKILL.md
+++ b/.claude/skills/ship-branch/SKILL.md
@@ -11,8 +11,7 @@ Orchestrate the complete branch-to-`master` path for web-sequence.
 
 ```text
 validate-branch
-  -> submit-branch
-  -> babysit-pr
+  -> submit-branch   # includes mandatory babysit-pr
   -> land-pr
 ```
 
@@ -24,19 +23,15 @@ Stop at the first failing step. Do not skip validation unless the user explicitl
 
 Use `validate-branch`. If it reports FAIL, stop and fix locally. If it reports PARTIAL, decide whether the blocker is acceptable before proceeding; mention the risk to the user.
 
-### 2. Submit PR
+### 2. Submit PR and babysit CI
 
-Use `submit-branch`. Create the PR against `master`. If a PR already exists, reuse it.
+Use `submit-branch` (pushes, opens or reuses the PR, then **always** runs `babysit-pr`). If babysit reports FAILED or BLOCKED, stop.
 
-### 3. Get CI Green
-
-Use `babysit-pr` on the PR. Let it monitor `Deploy to Stage`, fix code-caused failures, or report infra/secrets blockers. If it exhausts retries, stop.
-
-### 4. Merge
+### 3. Merge
 
 Confirm with the user before merging unless they explicitly said "ship it" or "ship this branch". Then use `land-pr`.
 
-### 5. Report
+### 4. Report
 
 On success:
 

--- a/.claude/skills/ship-branch/agents/openai.yaml
+++ b/.claude/skills/ship-branch/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ship Branch"
+  short_description: "Validate, PR, monitor CI, and merge a web-sequence branch."
+  default_prompt: "Ship the current web-sequence branch through validation, PR, CI, and merge."

--- a/.claude/skills/spot-check/SKILL.md
+++ b/.claude/skills/spot-check/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: spot-check
+description: >
+  Ad hoc, AI-driven verification of a specific behavior on ZenUML web-sequence —
+  not a new checked-in E2E test. Use after developing a feature, fixing a bug,
+  validating a branch, checking staging, or post-release on app.zenuml.com.
+  Drives Playwright (CLI or MCP) against the live app and #demo-frame preview.
+  Triggers on "spot check", "run a spot check on X", "spot check this fix",
+  "spot check on staging", "spot check staging.zenuml.com", "verify on prod".
+---
+
+# Spot Check
+
+A **spot check** is an ad hoc, AI-driven, ephemeral verification of a specific behavior. It is not meant to become a permanent regression suite entry unless the team explicitly promotes it later.
+
+**What it is NOT:** inventing a new `e2e/tests/*.spec.js` during the spot check, a full regression pass, or a substitute for CI.
+
+**What it CAN reuse:** existing Playwright specs as **recipes** (run them; do not edit them unless fixing a real bug).
+
+## Key principles
+
+- **Lightweight** — smallest set of checks that cover the delta.
+- **AI-driven** — plan assertions first, then execute with Playwright CLI and/or browser tools.
+- **Ephemeral** — steps live in the chat/report, not a new committed test file.
+- **Targeted** — verify the behavior under review, not every sidebar modal.
+- **Real world** — prefer deployed staging/prod when the question is “did the deploy work?”
+
+## Write the plan first
+
+**STOP.** Do not open the browser or run Playwright until the plan is written.
+
+Each planned check must name:
+
+1. **Behavior** — what changed or what you are verifying
+2. **Observable signal** — DOM text in `#demo-frame`, visible SVG, modal title, localStorage key, network response, etc.
+3. **Method** — Playwright step, `pnpm exec playwright test …`, screenshot, console check
+
+Each item must be independently pass/fail before you run it.
+
+```text
+Spot check plan: <short title>
+
+Target: <http://127.0.0.1:3000 | https://staging.zenuml.com | https://app.zenuml.com>
+  - [ ] <specific observable assertion>  [method]
+  - [ ] <specific observable assertion>  [method]
+
+Skipped: <anything out of scope> — <reason>
+```
+
+For **post-release** spot checks (release delta, commit triage, N/A rules), follow Step 5.5 in the **release-app** skill.
+
+For **branch validation** before push, follow Step 3 in the **validate-branch** skill after writing the plan here.
+
+## Choosing the environment
+
+| Situation | Target |
+|-----------|--------|
+| Unreleased frontend (local branch) | `yarn dev` → `http://127.0.0.1:3000` (Vite default) |
+| PR / “did staging deploy work?” | `https://staging.zenuml.com` |
+| Production issue or post-release | `https://app.zenuml.com` |
+| Prod-build bundling only (no deploy) | `PW_PROD_BUILD=1 pnpm exec playwright test e2e/tests/production-build.spec.js` |
+| CI already green on staging | Trust gate, then spot-check only the **delta** on staging or prod |
+
+## Verification methods
+
+| Signal | How |
+|--------|-----|
+| Diagram render / DSL | Set CodeMirror value or type; poll `#demo-frame` `contentDocument` for SVG + label text; screenshot preview |
+| Editor / modals / pages | Playwright on parent page (`getByTitle`, `getByRole('dialog')`) |
+| Save / localStorage | `Meta+s` / `Control+s`; poll `item-*` keys (see `e2e/tests/smoke.spec.js`) |
+| Deployed URL regression (broad) | `PW_BASE_URL=<url> pnpm exec playwright test --project=chromium` |
+| DSL shapes (recipe) | `PW_BASE_URL=<url> pnpm exec playwright test e2e/tests/dsl-spot-check.spec.js --project=chromium --workers=1` |
+| Fast prod sanity (recipe) | `PW_BASE_URL=https://app.zenuml.com pnpm exec playwright test --grep @smoke --project=chromium` |
+| Analytics (optional) | Mixpanel MCP if the change emits events |
+
+## Pre-flight (UI checks)
+
+Before interacting on any URL:
+
+1. **Suppress first-save dialog** (unsigned-in): in `page.addInitScript` or browser console before reload:
+   `localStorage.setItem('loginAndsaveMessageSeen', 'true')`
+2. **Preview iframe** — most diagram truth lives in `#demo-frame`, not the parent DOM. Use `page.frameLocator('#demo-frame')` or `contentDocument` polling like the smoke spec.
+3. **Third-party noise** — GTM/Zaraz/Paddle may throw; CI ignores known sources (`THIRD_PARTY_ERROR_SOURCES` in `smoke.spec.js`). Do not fail the spot check on those alone.
+
+## Workflow
+
+1. **Plan** — behavior, target URL, observable assertion per line (see above).
+2. **Choose environment** — table above.
+3. **Execute** — run each `[ ]` check; capture screenshots for diagram assertions (`render-diagram-*` style evidence in report).
+4. **Report** — pass / fail / skipped per assertion; attach screenshot paths or Playwright report URL.
+
+```text
+Spot check report: <title>
+- Target: <url>
+- Results: <n> pass, <n> fail, <n> skipped
+- Evidence: <screenshots / playwright report / CI run>
+- Failures: <assertion> — <what you saw>
+```
+
+## Playwright recipes (existing specs)
+
+Use these when they match the plan — **do not** treat running a spec as “the whole spot check” unless the delta is genuinely “general deploy health.”
+
+| Recipe | Command |
+|--------|---------|
+| Full staging gate (CI parity) | `PW_BASE_URL=https://staging.zenuml.com pnpm exec playwright test --project=chromium --workers=1` |
+| DSL + diagram screenshots | `PW_BASE_URL=<url> pnpm exec playwright test e2e/tests/dsl-spot-check.spec.js --project=chromium --workers=1` |
+| Prod smoke subset | `PW_BASE_URL=https://app.zenuml.com pnpm exec playwright test --grep @smoke --project=chromium` |
+| Static `dist/` guard | `pnpm build && PW_PROD_BUILD=1 pnpm exec playwright test e2e/tests/production-build.spec.js --project=chromium` |
+
+After a recipe run, open the HTML report if the user needs visual proof:
+
+```bash
+pnpm exec playwright show-report
+```
+
+## Browser tooling
+
+| Tool | Use for |
+|------|---------|
+| **Playwright CLI** | Repeatable checks, CI parity, screenshot attachments in report |
+| **Playwright MCP** (`user-playwright`) | Ad-hoc navigation when CLI is awkward |
+| **cursor-ide-browser** | Quick visual confirmation; use `browser_cdp` / `Runtime.evaluate` for `#demo-frame` innards |
+
+The preview iframe is same-origin accessible from Playwright tests; still scope selectors to the frame for diagram content.
+
+## Related skills
+
+| Skill | When |
+|-------|------|
+| **validate-branch** | Pre-push; write plan here, then execute |
+| **release-app** | Step 5.5 — release-delta spot check after publish |
+| **ship-branch** | Merge path; staging gate is CI, not a substitute for delta spot check |
+| **babysit-pr** | Fix CI, not product verification |
+
+## Rules
+
+- Never mark PASS without observing the planned signal (text in iframe, screenshot, or green Playwright assertion).
+- Never write a new spec file during a spot check unless the user asks to promote the check into CI.
+- Never spot-check prod with destructive flows (account deletion, billing, mass Firebase writes).
+- Prefer staging for experimental DSL edits; use prod for release-delta confirmation only.

--- a/.claude/skills/spot-check/agents/openai.yaml
+++ b/.claude/skills/spot-check/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Spot Check"
+  short_description: "Ad hoc Playwright verification on staging or prod with a written plan first."
+  default_prompt: "Run a spot check on staging.zenuml.com for the recent diagram rendering changes."

--- a/.claude/skills/submit-branch/SKILL.md
+++ b/.claude/skills/submit-branch/SKILL.md
@@ -1,11 +1,19 @@
 ---
 name: submit-branch
-description: Push the current ZenUML web-sequence branch and create or reuse a GitHub PR against master. Use when the user says "submit", "create PR", "open a pull request", "push and PR", or wants to publish branch work without merging. Does not fix CI or merge.
+description: Push the current ZenUML web-sequence branch, create or reuse a GitHub PR against master, then always run babysit-pr until CI is green or blocked. Use when the user says "submit", "create PR", "open a pull request", "push and PR", or wants to publish branch work without merging. Does not merge — use land-pr after babysit passes.
 ---
 
 # Submit Branch
 
-Publish the current branch as a PR for `ZenUml/web-sequence`.
+Publish the current branch as a PR for `ZenUml/web-sequence`, then **always** babysit CI on that PR.
+
+## Flow
+
+```text
+commit (if needed) → push → create or reuse PR → babysit-pr
+```
+
+Stop at the first failing step. Do not merge.
 
 ## Preconditions
 
@@ -48,8 +56,6 @@ Check for an existing PR:
 gh pr view --json number,title,url,state,isDraft,headRefName
 ```
 
-If one exists, report it and stop.
-
 If no PR exists, create one against `master`:
 
 ```bash
@@ -63,7 +69,18 @@ EOF
 )"
 ```
 
+If a PR already exists, note its number and URL — do not create a duplicate.
+
 Use Draft only if the user asks or if the branch is intentionally not ready. This repo does not have a documented draft gate that skips expensive PR E2E.
+
+### 4. Babysit CI (mandatory)
+
+**Always** invoke the **babysit-pr** skill on the PR from Step 3 (new or reused).
+
+- Pass the PR number explicitly if you have it.
+- Let babysit watch `Deploy to Stage`, diagnose failures, fix code-caused issues (up to its retry budget), and report final status.
+- If babysit ends **FAILED** or **BLOCKED**, stop here — do not merge. Tell the user what failed and whether a fix was pushed.
+- If babysit ends **PASSED** or checks are still **PENDING** with babysit still watching, report that state; do not call **land-pr** unless the user asked to ship/merge.
 
 ## PR Body Guidance
 
@@ -83,11 +100,11 @@ Submitted: PR #<number> <url>
 Branch: <branch>
 Base: master
 Validation included: <yes/no, summary>
+Babysit: PASSED|FAILED|PENDING|BLOCKED — <summary>
 Notes: <draft state, skipped checks, unrelated local files>
 ```
 
 ## Does Not
 
-- Run full validation by default; use `validate-branch`.
-- Monitor or fix CI; use `babysit-pr`.
-- Merge; use `land-pr`.
+- Run full validation by default; use `validate-branch` before submit when the branch needs local preflight.
+- Merge; use `land-pr` after babysit is green and the user wants to land.

--- a/.claude/skills/submit-branch/SKILL.md
+++ b/.claude/skills/submit-branch/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: submit-branch
+description: Push the current ZenUML web-sequence branch and create or reuse a GitHub PR against master. Use when the user says "submit", "create PR", "open a pull request", "push and PR", or wants to publish branch work without merging. Does not fix CI or merge.
+---
+
+# Submit Branch
+
+Publish the current branch as a PR for `ZenUml/web-sequence`.
+
+## Preconditions
+
+Run:
+
+```bash
+git status --short --branch
+git remote -v
+```
+
+Only proceed when modified files are clearly in scope for the branch. If the worktree mixes unrelated changes, ask which files to include. Never auto-commit unrelated files.
+
+## Steps
+
+### 1. Commit Scoped Changes If Needed
+
+If there are scoped uncommitted changes, stage only those files and commit with a concise message:
+
+```bash
+git add <specific-files>
+git commit -m "<type>: <summary>"
+```
+
+Do not amend or force-push unless the user explicitly asks.
+
+### 2. Push The Branch
+
+```bash
+git branch --show-current
+git push -u origin <branch>
+```
+
+If push is rejected, stop and report the reason. Do not force-push.
+
+### 3. Reuse Or Create PR
+
+Check for an existing PR:
+
+```bash
+gh pr view --json number,title,url,state,isDraft,headRefName
+```
+
+If one exists, report it and stop.
+
+If no PR exists, create one against `master`:
+
+```bash
+gh pr create --base master --title "<concise title>" --body "$(cat <<'EOF'
+## Summary
+- ...
+
+## Test plan
+- ...
+EOF
+)"
+```
+
+Use Draft only if the user asks or if the branch is intentionally not ready. This repo does not have a documented draft gate that skips expensive PR E2E.
+
+## PR Body Guidance
+
+Mention:
+
+- User-facing behavior changed
+- Build/config/deploy files changed
+- Validation actually run
+- Known skipped checks or environment blockers
+
+## Output
+
+Report:
+
+```text
+Submitted: PR #<number> <url>
+Branch: <branch>
+Base: master
+Validation included: <yes/no, summary>
+Notes: <draft state, skipped checks, unrelated local files>
+```
+
+## Does Not
+
+- Run full validation by default; use `validate-branch`.
+- Monitor or fix CI; use `babysit-pr`.
+- Merge; use `land-pr`.

--- a/.claude/skills/submit-branch/agents/openai.yaml
+++ b/.claude/skills/submit-branch/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Submit Branch"
-  short_description: "Push a web-sequence branch and open or reuse a PR."
-  default_prompt: "Submit the current web-sequence branch as a PR against master."
+  short_description: "Push a web-sequence branch, open or reuse a PR, then babysit CI until green or blocked."
+  default_prompt: "Submit the current web-sequence branch as a PR against master and babysit CI until it passes."

--- a/.claude/skills/submit-branch/agents/openai.yaml
+++ b/.claude/skills/submit-branch/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Submit Branch"
+  short_description: "Push a web-sequence branch and open or reuse a PR."
+  default_prompt: "Submit the current web-sequence branch as a PR against master."

--- a/.claude/skills/validate-branch/SKILL.md
+++ b/.claude/skills/validate-branch/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: validate-branch
+description: Run local validation checks for ZenUML web-sequence before pushing, opening a PR, or merging. Use when the user says "validate", "check branch", "run tests", "preflight", "is this ready", or before submit-branch or ship-branch. Covers Yarn/Vite/Jest/Playwright checks, build/release risk, and spot-check plans for UI/diagram changes (see spot-check skill).
+---
+
+# Validate Branch
+
+Verify the current branch is locally sane before it reaches GitHub Actions.
+
+## Repo Facts
+
+- Repository: `ZenUml/web-sequence`
+- Base branch: `master`
+- Package manager for local development: Yarn (`yarn install`, `yarn dev`, `yarn build`)
+- CI currently uses pnpm in GitHub Actions, so note any Yarn/pnpm divergence instead of hiding it.
+- App dev server is Vite on `http://127.0.0.1:3000` (Playwright can auto-start via `pnpm dev`).
+
+## Workflow
+
+### 1. Check Scope
+
+Run:
+
+```bash
+git status --short --branch
+git diff --name-only master...HEAD
+```
+
+If the worktree has unrelated local changes, do not stage or revert them. Validate the current branch changes and mention the unrelated files in the report.
+
+### 2. Choose Checks
+
+Run the smallest set that gives real confidence:
+
+- Always: `yarn build`
+- Unit-test changes or shared logic: `yarn test`
+- UI behavior changes: start `yarn dev`, test the changed flow in browser, and run `yarn test:e2e` when the smoke suite is relevant.
+- Release/extension changes: `yarn release` after `yarn build`
+- Firebase/functions changes: inspect `functions/package.json` and run the relevant functions build/test/deploy dry-run command if available.
+- Lint-sensitive changes: `yarn lint`, but if local ESLint is blocked by missing `eslint-config-synacor`, report that as an environment/config blocker and continue with other checks.
+
+Do not run expensive or stateful deploy commands unless the user explicitly asks.
+
+### 3. Feature spot check (UI / diagram changes)
+
+**When to skip:** docs-only, CI/workflow-only, unrelated skill files.
+
+For changes under `src/components`, `src/style.css`, `src/assets/tailwind.css`, `vite.config.js`, `e2e/`, or `@zenuml/core` integration:
+
+#### 3a. Write a spot check plan first
+
+Use the **spot-check** skill — write the plan (behavior, target URL, assertions, method) **before** touching the browser or Playwright.
+
+#### 3b. Choose how to test
+
+| Situation | Target |
+|-----------|--------|
+| Branch not deployed yet | `yarn dev` → `http://127.0.0.1:3000` |
+| Validating staging deploy | `PW_BASE_URL=https://staging.zenuml.com` + Playwright |
+| `@zenuml/core` / preview iframe | Assert inside `#demo-frame` (see **spot-check** skill) |
+| Broad DSL/renderer regression | Run `e2e/tests/dsl-spot-check.spec.js` as a recipe (optional) |
+
+#### 3c. Execute the plan
+
+Follow the **spot-check** skill workflow. Prefer Playwright CLI for repeatability; use browser MCP for ad-hoc steps.
+
+For each `[ ]` assertion: interact → observe signal → screenshot diagram/preview when visual proof matters.
+
+If every assertion passes: Step 3 **PASS**. If any fails: **FAIL** — include which assertion failed and evidence path; fix code, then re-run from §2.
+
+**Common gotchas:** see **spot-check** skill (iframe scope, `loginAndsaveMessageSeen`, third-party console noise). Branch-specific:
+
+- *Dev vs CI package manager:* local `yarn build`, CI `pnpm build` — run `pnpm build` if the change touches lockfile or Vite resolution.
+- *Empty preview canvas with passing text poll:* capture `render-diagram-*` screenshot; layout/CSS regressions need visual evidence.
+
+### 4. Report
+
+Use this shape:
+
+```text
+Validation: PASS|FAIL|PARTIAL
+- Build: ...
+- Tests: ...
+- Browser smoke: ...
+- Skipped: ... (reason)
+- Unrelated local changes: ...
+```
+
+FAIL means a required check failed. PARTIAL means useful checks passed but one check could not run because of environment, credentials, missing config, or an intentionally skipped scope.
+
+## Rules
+
+- Never mark validation PASS if a required check was skipped or blocked.
+- Never clean, revert, or stage unrelated local files.
+- Prefer fixing reproducible local failures before suggesting CI retry.
+- Preserve the exact failing command and the important error lines in the final report.

--- a/.claude/skills/validate-branch/agents/openai.yaml
+++ b/.claude/skills/validate-branch/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Validate Branch"
+  short_description: "Run web-sequence local preflight checks before PR or merge."
+  default_prompt: "Validate the current web-sequence branch and report what passed, failed, or was skipped."


### PR DESCRIPTION
## Summary
- Add **spot-check** skill (migrated from conf-app): plan-first ad hoc verification on local/staging/prod with Playwright recipes (`smoke`, `dsl-spot-check`, `@smoke`).
- Extend **release-app** with Step 5 (wait for deploy-prod + CI `@smoke`) and Step 5.5 (release-delta spot check with commit triage).
- Extend **validate-branch** to use spot-check for UI/diagram changes.
- Add **submit-branch**, **ship-branch**, **land-pr**, **babysit-pr** skills for the branch→master workflow.

## Test plan
- [x] Skills-only change; no app/runtime code
- [ ] CI `Deploy to Stage` build job (expected pass — no product diff)


Made with [Cursor](https://cursor.com)