### PR TITLE
fix(e2e): align testids header-menu/header-* + skip production-build on remote

### DIFF
--- a/e2e/tests/library.spec.js
+++ b/e2e/tests/library.spec.js
@@ -117,6 +117,8 @@ async function seedItem(page, { title, dsl, firstSave = false }) {
   await setTitle(page, title);
   await typeDsl(page, dsl);
   await expect(editorLocator(page)).toContainText(dsl.split('\n')[0]);
+  // Save lives inside the header-menu dropdown — open it first.
+  await page.locator('[data-testid="header-menu"]').click();
   await page.locator('[data-testid="header-save"]').click();
   await dismissSaveNoticeIfPresent(page, { expected: firstSave });
 }
@@ -147,7 +149,8 @@ test('library lists local items and SearchInput filters them', async ({ page }) 
     firstSave: true,
   });
 
-  // New diagram, then seed item 2 (distinct title so search can discriminate).
+  // New lives inside the header-menu dropdown — open it first.
+  await page.locator('[data-testid="header-menu"]').click();
   await page.locator('[data-testid="header-new"]').click();
   await expect(editorLocator(page)).toBeVisible();
   await seedItem(page, {

--- a/e2e/tests/persistence.spec.js
+++ b/e2e/tests/persistence.spec.js
@@ -185,7 +185,8 @@ test('header-new: clicking New resets editor to the default starter DSL', async 
   await typeDsl(page, CUSTOM_DSL);
   await expect(editorLocator(page)).toContainText('CustomActor');
 
-  // Click the "New" button in the header.
+  // Open the app menu then click "New" (New lives inside the header-menu dropdown).
+  await page.locator('[data-testid="header-menu"]').click();
   await page.locator('[data-testid="header-new"]').click();
 
   // #8: with unsaved edits, New first asks to confirm discarding them. Confirm the

--- a/e2e/tests/production-build.spec.js
+++ b/e2e/tests/production-build.spec.js
@@ -1,5 +1,11 @@
 import { test, expect } from '@playwright/test';
 import { existsSync, readdirSync } from 'fs';
+
+// These tests check the LOCAL web/dist build and hit localhost:PREVIEW_PORT directly.
+// They must not run when PW_BASE_URL targets a remote host (staging/prod gate).
+test.beforeEach(() => {
+  test.skip(!!process.env.PW_BASE_URL, 'production-build checks require a local web/dist build');
+});
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 import { PREVIEW_PORT } from '../../playwright.config.js';

--- a/web/src/app/AppRoot.test.tsx
+++ b/web/src/app/AppRoot.test.tsx
@@ -199,7 +199,7 @@ describe('AppRoot', () => {
     // Save retired into the app menu; the passive save-state indicator + the app
     // menu trigger are the header's new persistent affordances.
     expect(screen.getByTestId('header-savestate')).toBeInTheDocument();
-    expect(screen.getByTestId('app-menu-trigger')).toBeInTheDocument();
+    expect(screen.getByTestId('header-menu')).toBeInTheDocument();
   });
 
   // The Save button is gone; ⌘S is the advertised manual-save accelerator (app menu
@@ -288,8 +288,8 @@ describe('AppRoot — M04 save-seam plan limit', () => {
     // Save retired from a top-level button into the app menu (logo ▾). Manual save
     // now: open the app menu, click its Save item.
     await act(async () => {
-      await userEvent.click(screen.getByTestId('app-menu-trigger'));
-      await userEvent.click(await screen.findByTestId('app-menu-save'));
+      await userEvent.click(screen.getByTestId('header-menu'));
+      await userEvent.click(await screen.findByTestId('header-save'));
     });
   }
 
@@ -766,8 +766,8 @@ describe('AppRoot — analytics envelope parity (REQ-ANL-1, adversarial review)'
     });
     await waitFor(() => expect(subSvc.retrieveSubscription).toHaveBeenCalledWith('u1'));
     await act(async () => {
-      await userEvent.click(screen.getByTestId('app-menu-trigger'));
-      await userEvent.click(await screen.findByTestId('app-menu-save'));
+      await userEvent.click(screen.getByTestId('header-menu'));
+      await userEvent.click(await screen.findByTestId('header-save'));
     });
     await waitFor(() => expect(screen.queryByTestId('limit-notice')).toBeInTheDocument());
     const env = lastEnvelope('Free Limit');
@@ -977,7 +977,7 @@ describe('AppRoot — analytics envelope parity (REQ-ANL-1, adversarial review)'
 // M05 — embed mode (RM-2 / REQ-EMB-1).
 //
 // DISCRIMINATING-TESTID CONTRACT (verified against the code): AppHeader exposes
-// `header-title`/`app-menu-trigger`/`header-savestate` and Sidebar exposes `sidebar-editor`/
+// `header-title`/`header-menu`/`header-savestate` and Sidebar exposes `sidebar-editor`/
 // `sidebar-library` — these are PRESENT in normal mode (the CONTROL test pins them),
 // so their ABSENCE in embed is a genuine revert→fail signal (there is no `app-header`
 // / bare `sidebar` id that would pass vacuously). The URL is driven via
@@ -989,7 +989,7 @@ describe('AppRoot — embed mode (RM-2 / REQ-EMB-1)', () => {
     window.history.replaceState({}, '', '/');
     render(<AppRoot />);
     expect(await screen.findByTestId('header-title')).toBeInTheDocument();
-    expect(screen.getByTestId('app-menu-trigger')).toBeInTheDocument();
+    expect(screen.getByTestId('header-menu')).toBeInTheDocument();
     // At least one sidebar-<panel> node renders in normal mode.
     expect(screen.getAllByTestId(/^sidebar-/).length).toBeGreaterThan(0);
     // The embed shell is NOT present in normal mode.
@@ -1003,7 +1003,7 @@ describe('AppRoot — embed mode (RM-2 / REQ-EMB-1)', () => {
     expect(await screen.findByTestId('embed-header')).toBeInTheDocument();
     // DISCRIMINATING absence (these ids EXIST in normal mode per the control above):
     expect(screen.queryByTestId('header-title')).toBeNull();
-    expect(screen.queryByTestId('app-menu-trigger')).toBeNull();
+    expect(screen.queryByTestId('header-menu')).toBeNull();
     expect(screen.queryAllByTestId(/^sidebar-/)).toHaveLength(0);
     // No save/auth controls in embed.
     expect(screen.queryByTestId('header-savestate')).toBeNull();

--- a/web/src/components/header/AppHeader.test.tsx
+++ b/web/src/components/header/AppHeader.test.tsx
@@ -84,16 +84,16 @@ describe('AppHeader', () => {
   it('app menu Save item calls onSave', async () => {
     const onSave = vi.fn();
     render(<AppHeader {...baseProps} onSave={onSave} />);
-    await userEvent.click(screen.getByTestId('app-menu-trigger'));
-    await userEvent.click(await screen.findByTestId('app-menu-save'));
+    await userEvent.click(screen.getByTestId('header-menu'));
+    await userEvent.click(await screen.findByTestId('header-save'));
     expect(onSave).toHaveBeenCalled();
   });
 
   it('app menu New fires onNew immediately when there are no unsaved changes', async () => {
     const onNew = vi.fn();
     render(<AppHeader {...baseProps} unsavedCount={0} onNew={onNew} />);
-    await userEvent.click(screen.getByTestId('app-menu-trigger'));
-    await userEvent.click(await screen.findByTestId('app-menu-new'));
+    await userEvent.click(screen.getByTestId('header-menu'));
+    await userEvent.click(await screen.findByTestId('header-new'));
     expect(onNew).toHaveBeenCalled();
     expect(screen.queryByTestId('confirm-ok')).not.toBeInTheDocument();
   });
@@ -102,8 +102,8 @@ describe('AppHeader', () => {
   it('app menu New opens a discard-confirm (not onNew) when unsavedCount > 0', async () => {
     const onNew = vi.fn();
     render(<AppHeader {...baseProps} unsavedCount={2} onNew={onNew} />);
-    await userEvent.click(screen.getByTestId('app-menu-trigger'));
-    await userEvent.click(await screen.findByTestId('app-menu-new'));
+    await userEvent.click(screen.getByTestId('header-menu'));
+    await userEvent.click(await screen.findByTestId('header-new'));
     expect(onNew).not.toHaveBeenCalled();
     const dialog = await screen.findByRole('dialog');
     expect(dialog).toHaveTextContent('Discard unsaved changes?');
@@ -114,14 +114,14 @@ describe('AppHeader', () => {
     const onNew = vi.fn();
     const { rerender } = render(<AppHeader {...baseProps} unsavedCount={2} onNew={onNew} />);
 
-    await userEvent.click(screen.getByTestId('app-menu-trigger'));
-    await userEvent.click(await screen.findByTestId('app-menu-new'));
+    await userEvent.click(screen.getByTestId('header-menu'));
+    await userEvent.click(await screen.findByTestId('header-new'));
     await userEvent.click(await screen.findByTestId('confirm-cancel'));
     expect(onNew).not.toHaveBeenCalled();
 
     rerender(<AppHeader {...baseProps} unsavedCount={2} onNew={onNew} />);
-    await userEvent.click(screen.getByTestId('app-menu-trigger'));
-    await userEvent.click(await screen.findByTestId('app-menu-new'));
+    await userEvent.click(screen.getByTestId('header-menu'));
+    await userEvent.click(await screen.findByTestId('header-new'));
     await userEvent.click(await screen.findByTestId('confirm-ok'));
     expect(onNew).toHaveBeenCalledTimes(1);
   });
@@ -138,16 +138,16 @@ describe('AppHeader', () => {
         onOpenHelp={onOpenHelp}
       />,
     );
-    await userEvent.click(screen.getByTestId('app-menu-trigger'));
-    await userEvent.click(await screen.findByTestId('app-menu-settings'));
+    await userEvent.click(screen.getByTestId('header-menu'));
+    await userEvent.click(await screen.findByTestId('header-settings'));
     expect(onOpenSettings).toHaveBeenCalled();
 
-    await userEvent.click(screen.getByTestId('app-menu-trigger'));
-    await userEvent.click(await screen.findByTestId('app-menu-create-new'));
+    await userEvent.click(screen.getByTestId('header-menu'));
+    await userEvent.click(await screen.findByTestId('header-create-new'));
     expect(onOpenCreateNew).toHaveBeenCalled();
 
-    await userEvent.click(screen.getByTestId('app-menu-trigger'));
-    await userEvent.click(await screen.findByTestId('app-menu-help'));
+    await userEvent.click(screen.getByTestId('header-menu'));
+    await userEvent.click(await screen.findByTestId('header-help'));
     expect(onOpenHelp).toHaveBeenCalled();
   });
 
@@ -157,12 +157,12 @@ describe('AppHeader', () => {
     render(
       <AppHeader {...baseProps} onOpenCheatSheet={onOpenCheatSheet} onOpenShortcuts={onOpenShortcuts} />,
     );
-    await userEvent.click(screen.getByTestId('app-menu-trigger'));
-    await userEvent.click(await screen.findByTestId('app-menu-cheatsheet'));
+    await userEvent.click(screen.getByTestId('header-menu'));
+    await userEvent.click(await screen.findByTestId('header-cheatsheet'));
     expect(onOpenCheatSheet).toHaveBeenCalled();
 
-    await userEvent.click(screen.getByTestId('app-menu-trigger'));
-    await userEvent.click(await screen.findByTestId('app-menu-shortcuts'));
+    await userEvent.click(screen.getByTestId('header-menu'));
+    await userEvent.click(await screen.findByTestId('header-shortcuts'));
     expect(onOpenShortcuts).toHaveBeenCalled();
   });
 
@@ -172,13 +172,13 @@ describe('AppHeader', () => {
     const { rerender } = render(
       <AppHeader {...baseProps} paymentEnabled={false} onOpenPricing={onOpenPricing} />,
     );
-    await userEvent.click(screen.getByTestId('app-menu-trigger'));
-    expect(screen.queryByTestId('app-menu-pricing')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByTestId('header-menu'));
+    expect(screen.queryByTestId('header-pricing')).not.toBeInTheDocument();
     await closeMenu();
 
     rerender(<AppHeader {...baseProps} paymentEnabled onOpenPricing={onOpenPricing} />);
-    await userEvent.click(screen.getByTestId('app-menu-trigger'));
-    await userEvent.click(await screen.findByTestId('app-menu-pricing'));
+    await userEvent.click(screen.getByTestId('header-menu'));
+    await userEvent.click(await screen.findByTestId('header-pricing'));
     expect(onOpenPricing).toHaveBeenCalled();
   });
 
@@ -302,7 +302,7 @@ describe('AppHeader', () => {
   // stay in the tree at every width (the condense only touches Share/Present labels).
   it('keeps logo + filename + savestate + account in the tree (not responsively removed)', () => {
     render(<AppHeader {...baseProps} user={mockUser} />);
-    expect(screen.getByTestId('app-menu-trigger')).toBeInTheDocument();
+    expect(screen.getByTestId('header-menu')).toBeInTheDocument();
     expect(screen.getByTestId('filemenu-trigger')).toBeInTheDocument();
     expect(screen.getByTestId('header-title')).toBeInTheDocument();
     expect(screen.getByTestId('header-savestate')).toBeInTheDocument();

--- a/web/src/components/header/AppMenu.tsx
+++ b/web/src/components/header/AppMenu.tsx
@@ -82,7 +82,7 @@ export function AppMenu({
       <MenuTrigger asChild>
         <button
           type="button"
-          data-testid="app-menu-trigger"
+          data-testid="header-menu"
           aria-label="App menu"
           className={cn(
             'flex items-center gap-1.5 shrink-0 rounded-lg px-1.5 h-9',
@@ -104,33 +104,33 @@ export function AppMenu({
         </button>
       </MenuTrigger>
       <MenuContent align="start">
-        <MenuItem data-testid="app-menu-new" onSelect={() => onNew()}>
+        <MenuItem data-testid="header-new" onSelect={() => onNew()}>
           New
         </MenuItem>
-        <MenuItem data-testid="app-menu-create-new" onSelect={() => onOpenCreateNew?.()}>
+        <MenuItem data-testid="header-create-new" onSelect={() => onOpenCreateNew?.()}>
           New from template…
         </MenuItem>
         <MenuSeparator />
-        <MenuItem data-testid="app-menu-settings" onSelect={() => onOpenSettings?.()}>
+        <MenuItem data-testid="header-settings" onSelect={() => onOpenSettings?.()}>
           Settings
         </MenuItem>
-        <MenuItem data-testid="app-menu-shortcuts" onSelect={() => onOpenShortcuts?.()}>
+        <MenuItem data-testid="header-shortcuts" onSelect={() => onOpenShortcuts?.()}>
           Keyboard shortcuts
         </MenuItem>
-        <MenuItem data-testid="app-menu-cheatsheet" onSelect={() => onOpenCheatSheet?.()}>
+        <MenuItem data-testid="header-cheatsheet" onSelect={() => onOpenCheatSheet?.()}>
           DSL cheat sheet
         </MenuItem>
-        <MenuItem data-testid="app-menu-help" onSelect={() => onOpenHelp?.()}>
+        <MenuItem data-testid="header-help" onSelect={() => onOpenHelp?.()}>
           Help
         </MenuItem>
         {paymentEnabled && (
-          <MenuItem data-testid="app-menu-pricing" onSelect={() => onOpenPricing?.()}>
+          <MenuItem data-testid="header-pricing" onSelect={() => onOpenPricing?.()}>
             Pricing
           </MenuItem>
         )}
         <MenuSeparator />
         <MenuItem
-          data-testid="app-menu-save"
+          data-testid="header-save"
           onSelect={() => onSave()}
           className="flex items-center"
         >


### PR DESCRIPTION
## Summary
- Rename `app-menu-trigger` → `header-menu` and all `app-menu-*` item testids → `header-*` in `AppMenu.tsx` to match the E2E contract documented in `embed.spec.js`
- Update all unit tests (`AppHeader.test.tsx`, `AppRoot.test.tsx`) to use the renamed testids
- Fix `persistence.spec.js` and `library.spec.js` to open the menu dropdown before clicking `header-new`/`header-save` (previously clicked directly as if they were top-level buttons, which they're not)
- Add `test.beforeEach` skip guard in `production-build.spec.js` so it skips when `PW_BASE_URL` targets a remote host (staging/prod gate) — these tests check local disk and `localhost:PREVIEW_PORT`, not the deployed site

## Root cause
The E2E staging gate started running for the first time after PR #797 merged (conf-app parity). It surfaced a testid naming mismatch: the component used `app-menu-trigger`/`app-menu-*` but `embed.spec.js` explicitly documents the contract as `header-menu`/`header-*`. The `production-build.spec.js` failures were a separate issue: those tests assume a local build and local preview server, not a deployed URL.

## Test plan
- `pnpm -C web test` — all 815 tests pass (813 pass, 2 skipped, same baseline)
- E2E staging gate will re-run on merge; expect all 13 previously-failing tests to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)