### PR TITLE
fix(e2e): update embed CONTROL sidebar count 2→4 (templates+help rail buttons)

### DIFF
--- a/e2e/tests/embed.spec.js
+++ b/e2e/tests/embed.spec.js
@@ -57,8 +57,8 @@ test('CONTROL: normal (non-embed) mode renders the real header, sidebar, and edi
 
   await expect(page.getByTestId('header-title')).toBeVisible();
   await expect(page.getByTestId('header-menu')).toBeVisible();
-  // Both sidebar panels render unconditionally in normal mode.
-  await expect(page.getByTestId(/^sidebar-/)).toHaveCount(2);
+  // Sidebar rail buttons render unconditionally in normal mode (editor + library + templates + help = 4).
+  await expect(page.getByTestId(/^sidebar-/)).toHaveCount(4);
   await expect(page.getByTestId('dsl-editor')).toBeVisible();
   // The embed shell is NOT present in normal mode.
   await expect(page.getByTestId('embed-header')).toHaveCount(0);


### PR DESCRIPTION
## Summary
- The CONTROL test in `embed.spec.js` asserted `sidebar-*` count = 2 (editor + library). `Sidebar.tsx` now renders 4 rail buttons: editor, library, templates, help — so the count was stale.
- Updated to `toHaveCount(4)` to match the actual component.

## Legitimacy (PUA guard note)
This is a count correction, not a weakening. The test's discriminating purpose — proving sidebar IS present in normal mode (count > 0) so the embed assertion of count = 0 is meaningful — is unchanged. The count was empirically wrong, verified directly from `web/src/components/Sidebar.tsx`.

## Test plan
- `Sidebar.tsx` renders exactly 4 `sidebar-*` testids: `sidebar-editor`, `sidebar-library`, `sidebar-templates`, `sidebar-help`
- The embed test's guard (`toHaveCount(0)`) is not touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)