### PR TITLE
fix(e2e): hub-adapt staging-gate root specs (unblocks master E2E gate + draft release)

### DIFF
--- a/e2e/tests/dsl-spot-check.spec.js
+++ b/e2e/tests/dsl-spot-check.spec.js
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { suppressOneTimeModals } from './helpers/onetime';
+import { openEditor } from './helpers/hub';
 
 // DSL spot-check: type DSL into the CodeMirror 6 editor of the NEW app and prove
 // the full render path works end to end:
@@ -43,7 +44,9 @@ test.beforeEach(async ({ page }) => {
     throw err;
   });
   await suppressOneTimeModals(page); // M04: keep onboarding/pledge from trapping focus
-  await page.goto('/');
+  // Hub (PRs #800/#801): '/' renders the HomeView library, not the editor —
+  // click through the hub's New CTA to reach the editor surface.
+  await openEditor(page);
 });
 
 test('typed DSL renders an SVG diagram in the preview iframe', async ({ page }) => {

--- a/e2e/tests/embed.spec.js
+++ b/e2e/tests/embed.spec.js
@@ -5,8 +5,8 @@
 // spec proves the embed surface:
 //   - the embed header (embed-header + embed-open-link) is shown;
 //   - the full-app CHROME is suppressed — the real header (header-title/header-menu),
-//     the sidebar panels (sidebar-editor/sidebar-library) and the editor (dsl-editor)
-//     are all ABSENT;
+//     the editor work surface (editor-region) and the editor (dsl-editor) are all
+//     ABSENT;
 //   - the inline `?code=` diagram renders its CONTENT in the preview iframe
 //     (embed mode hides @zenuml/core's footer chrome — incl. its only svgs — so we
 //     assert the diagram body's message label / participant, not `#mounting-point svg`);
@@ -14,19 +14,29 @@
 //
 // DISCRIMINATING-ID CONTRACT (ground truth — verified against the source, NOT
 // invented). The chrome ids used for the ABSENCE assertions all EXIST in normal
-// (non-embed) mode, so their absence in embed is a genuine revert→fail signal:
+// (non-embed) editor mode, so their absence in embed is a genuine revert→fail
+// signal:
 //   - AppHeader.tsx exposes `header-title` + `header-menu` (there is NO `app-header`).
-//   - Sidebar.tsx renders `sidebar-editor` + `sidebar-library` unconditionally
-//     (there is NO bare `sidebar` id).
+//   - Layout.tsx exposes `editor-region` — the split-pane editor work surface.
 //   - The editor is `dsl-editor`.
-// A CONTROL test below pins these against normal mode so the discriminator is
-// observable: reverting AppRoot's `if (isEmbed)` short-circuit makes the header /
-// sidebar / editor reappear under `?embed`, failing the embed test.
+// The Sidebar icon rail this contract previously leaned on (`sidebar-editor` /
+// `sidebar-library`) was deliberately removed app-wide by f023f89 ("feat(hub):
+// no-rail layout…") — sidebar-* ids no longer exist in ANY mode and cannot ground
+// the normal-vs-embed contrast (mirrors the same re-ground in
+// web/src/app/AppRoot.test.tsx, "AppRoot — embed mode" describe).
+// A CONTROL test below pins these against normal editor mode so the discriminator
+// is observable: reverting AppRoot's `if (isEmbed)` short-circuit makes the header
+// / editor surface reappear under `?embed`, failing the embed test.
+//
+// Hub (PRs #800/#801): bare '/' now renders the HomeView library, so "normal
+// (non-embed) mode" — the CONTROL's subject — lives at an editor URL, reached by
+// clicking through the hub's New CTA (openEditor helper).
 //
 // The webServer (playwright.config.js) boots `pnpm -C web dev` on :3000.
 
 import { test, expect } from '@playwright/test';
 import { suppressOneTimeModals } from './helpers/onetime';
+import { openEditor } from './helpers/hub';
 
 const CANONICAL_APP_ORIGIN = 'https://app.zenuml.com';
 const EMBED_URL = '/?embed&code=A.method()&title=Demo';
@@ -47,18 +57,26 @@ test.beforeEach(async ({ page }) => {
 
 // ──────────────────────────────────────────────────────────────────────────────
 // CONTROL — pin the discriminator: the chrome ids the embed test asserts ABSENT
-// are genuinely PRESENT in normal (non-embed) mode. Normal-mode boot opens the
-// one-time onboarding modal, so suppress it (embed mode skips those effects and
-// therefore needs no suppression — see the embed tests below).
+// are genuinely PRESENT in normal (non-embed) editor mode. Normal-mode boot opens
+// the one-time onboarding modal, so suppress it (embed mode skips those effects
+// and therefore needs no suppression — see the embed tests below).
 // ──────────────────────────────────────────────────────────────────────────────
-test('CONTROL: normal (non-embed) mode renders the real header, sidebar, and editor', async ({ page }) => {
+test('CONTROL: normal (non-embed) editor mode renders the real header and editor surface', async ({ page }) => {
   await suppressOneTimeModals(page);
-  await page.goto('/');
+  // Hub (PRs #800/#801): '/' renders the HomeView library, so normal editor mode
+  // is reached by clicking through the hub's New CTA.
+  await openEditor(page);
 
   await expect(page.getByTestId('header-title')).toBeVisible();
   await expect(page.getByTestId('header-menu')).toBeVisible();
-  // Sidebar rail buttons render unconditionally in normal mode (editor + library + templates + help = 4).
-  await expect(page.getByTestId(/^sidebar-/)).toHaveCount(4);
+  // f023f89 ("feat(hub): no-rail layout…") removed the Sidebar icon rail app-wide,
+  // so the old `getByTestId(/^sidebar-/)` count-4 check could only fail; sidebar-*
+  // ids exist in NO mode and can no longer ground the normal-vs-embed contrast.
+  // Re-grounded on `editor-region` (Layout.tsx): present in normal editor mode,
+  // and the embed branch returns before Layout ever mounts, so its absence under
+  // ?embed (asserted below) genuinely discriminates. Mirrors the unit-level
+  // re-ground in web/src/app/AppRoot.test.tsx ("AppRoot — embed mode" describe).
+  await expect(page.getByTestId('editor-region')).toBeVisible();
   await expect(page.getByTestId('dsl-editor')).toBeVisible();
   // The embed shell is NOT present in normal mode.
   await expect(page.getByTestId('embed-header')).toHaveCount(0);
@@ -67,7 +85,7 @@ test('CONTROL: normal (non-embed) mode renders the real header, sidebar, and edi
 // ──────────────────────────────────────────────────────────────────────────────
 // Embed suppresses the full-app chrome and shows the minimal embed header.
 // ──────────────────────────────────────────────────────────────────────────────
-test('?embed hides the real header, sidebar, and editor; shows the embed header', async ({ page }) => {
+test('?embed hides the real header and editor surface; shows the embed header', async ({ page }) => {
   await page.goto(EMBED_URL);
 
   // The embed shell is present.
@@ -79,10 +97,14 @@ test('?embed hides the real header, sidebar, and editor; shows the embed header'
   // this fails — code rendering alone would NOT catch a dropped ?title).
   await expect(page.getByTestId('embed-title')).toHaveText('Demo');
 
-  // The full-app chrome (ids that EXIST in normal mode, per the control) is gone.
+  // The full-app chrome (ids that EXIST in normal editor mode, per the control)
+  // is gone. The old `sidebar-*` count-0 check was removed: f023f89 deleted the
+  // Sidebar rail app-wide, so that assertion had become vacuously true (it could
+  // never fail and so guarded nothing); `editor-region` — pinned PRESENT by the
+  // control — is the chrome element the embed branch genuinely suppresses.
   await expect(page.getByTestId('header-title')).toHaveCount(0);
   await expect(page.getByTestId('header-menu')).toHaveCount(0);
-  await expect(page.getByTestId(/^sidebar-/)).toHaveCount(0);
+  await expect(page.getByTestId('editor-region')).toHaveCount(0);
   await expect(page.getByTestId('dsl-editor')).toHaveCount(0);
 });
 

--- a/e2e/tests/helpers/hub.js
+++ b/e2e/tests/helpers/hub.js
@@ -1,0 +1,57 @@
+// Shared E2E helpers for the Hub UI (PRs #800/#801; f023f89 "no-rail layout").
+//
+// Since the hub landed, bare '/' no longer boots the editor: it renders the
+// HomeView library page (data-testid="home-view"), and the editor is reached by
+// clicking "New diagram" (home-empty-new — empty-library CTA) or the header New
+// button (home-new). The Sidebar icon rail was removed app-wide (f023f89), so
+// nothing navigates via sidebar-* anymore. Editor URLs (/?id= or ?code=/?embed)
+// still render their surface directly without passing through the hub.
+//
+// Every spec that needs the editor goes through openEditor(); specs that need
+// the library grid go through gotoHome(). Keeping the click-through in ONE place
+// means the next hub-routing change is a one-file fix.
+
+import { expect } from '@playwright/test';
+
+const HOME_VIEW = '[data-testid="home-view"]';
+const EDITOR_SURFACE = '[data-testid="dsl-editor"] .cm-content';
+
+/**
+ * Navigate to `url` (default '/') and end up in the editor.
+ *
+ * - If the URL renders the HomeView hub, click through its New CTA
+ *   (home-empty-new when the library is empty, else home-new).
+ * - If the URL renders the editor directly (e.g. '/?id=…' or '/?code=…'),
+ *   just wait for the editor surface.
+ *
+ * React renders after the 'load' event page.goto resolves on, so we first wait
+ * for WHICHEVER surface this URL produces (home-view or the CM6 editor) before
+ * deciding — a bare isVisible() right after goto races the first render.
+ */
+export async function openEditor(page, { url = '/' } = {}) {
+  await page.goto(url);
+  const homeView = page.locator(HOME_VIEW);
+  const editorSurface = page.locator(EDITOR_SURFACE);
+  await expect(homeView.or(editorSurface).first()).toBeVisible({ timeout: 15_000 });
+  if (await homeView.isVisible()) {
+    const emptyCta = page.locator('[data-testid="home-empty-new"]');
+    if (await emptyCta.isVisible()) {
+      await emptyCta.click();
+    } else {
+      await page.locator('[data-testid="home-new"]').click();
+    }
+  }
+  await expect(editorSurface).toBeVisible({ timeout: 15_000 });
+}
+
+/**
+ * Navigate to the HomeView library page ('/').
+ *
+ * A FULL navigation (not client-side breadcrumb) so the signed-out useItems
+ * mount re-reads the localItems index from a clean slate — robust regardless of
+ * whether the in-page subscription has caught up.
+ */
+export async function gotoHome(page) {
+  await page.goto('/');
+  await expect(page.locator(HOME_VIEW)).toBeVisible({ timeout: 15_000 });
+}

--- a/e2e/tests/library.spec.js
+++ b/e2e/tests/library.spec.js
@@ -1,26 +1,34 @@
-// M03 Task 15 — Library panel E2E (signed-out / local flows only).
+// M03 Task 15 — Library E2E (signed-out / local flows only).
+//
+// Hub (PRs #800/#801; f023f89 "no-rail layout"): the in-editor Library PANEL was
+// retired — the Sidebar icon rail (sidebar-library) and LibraryPanel no longer
+// render anywhere. The web library IS the HomeView page at '/': rows are
+// home-card-<id> cards in home-grid, search is home-search (same SearchInput
+// component, so the clear affordance is still search-clear), and the bulk
+// Export-all / Import controls (lib-export-all / lib-import-input) were re-homed
+// into the HomeView header (see web/src/components/home/HomeView.tsx). Each
+// test's INTENT is unchanged — list, filter, export, import — only the surface
+// the library lives on moved.
 //
 // What this covers WITHOUT the Firebase emulator:
-//   1. Library panel renders the user's locally-saved diagrams.
-//   2. SearchInput filters the rendered list (client-side, in memory).
+//   1. HomeView grid renders the user's locally-saved diagrams.
+//   2. SearchInput filters the rendered grid (client-side, in memory).
 //   3. Export-all triggers a JSON file download.
-//   4. Importing a small JSON adds a new row.
+//   4. Importing a small JSON adds a new card.
 //
 // DEFERRED to the staging gate (require Firebase auth/emulator, NOT testable
 // signed-out): folder CRUD (writes users/{uid}.folders) and create-share (POST
 // /create-share reads the cloud item doc + needs a fresh ID token). Same auth
 // note as persistence.spec.js / M02.
 //
-// Load-bearing implementation fact (verified against web/src/hooks/useItems.ts):
-// signed-out, `useItems` reads the localItems index EXACTLY ONCE per mount
-// (effect deps [uid, svc], no storage listener). Items saved/imported *after*
-// page load do NOT appear until the next full page load. So the seed → reload →
-// open-library shape below is required, not incidental — mirroring how
-// persistence.spec.js reloads to read restored state. Search/export operate on
-// the already-loaded list and need no reload.
+// Navigation note: seeding happens in the EDITOR (reached through the hub's New
+// CTA — openEditor); reading the library back happens by a FULL navigation to
+// '/' (gotoHome), which freshly mounts useItems and re-reads the localItems
+// index regardless of in-page subscription timing.
 
 import { test, expect } from '@playwright/test';
 import { suppressOneTimeModals } from './helpers/onetime';
+import { openEditor, gotoHome } from './helpers/hub';
 
 const selectAll = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
 
@@ -45,7 +53,7 @@ function isThirdPartyError(err) {
   return THIRD_PARTY_ERROR_SOURCES.some((src) => haystack.includes(src));
 }
 
-/** Navigate to the app with a clean localStorage slate (see persistence.spec.js). */
+/** Navigate to the EDITOR with a clean localStorage slate (see persistence.spec.js). */
 async function gotoFresh(page) {
   // M04: the first load would open the Onboarding/Support-pledge one-time modals on
   // a clean slate; seed their flags via an init script before any goto so the
@@ -54,7 +62,9 @@ async function gotoFresh(page) {
   await suppressOneTimeModals(page);
   await page.goto('/');
   await page.evaluate(() => localStorage.clear());
-  await page.goto('/');
+  // Hub: '/' is the HomeView library — seeding drives the editor's header, so
+  // click through the hub's New CTA (empty library → home-empty-new).
+  await openEditor(page);
 }
 
 function editorLocator(page) {
@@ -123,12 +133,15 @@ async function seedItem(page, { title, dsl, firstSave = false }) {
   await dismissSaveNoticeIfPresent(page, { expected: firstSave });
 }
 
-/** Reload, then re-open the Library panel (uiStore.activePanel resets on reload). */
+/**
+ * Navigate to the library. Hub (PRs #800/#801): the library is no longer an
+ * in-editor side panel (sidebar-library + library-panel are gone — f023f89
+ * removed the rail and LibraryPanel was retired); it is the HomeView page at
+ * '/'. gotoHome is a FULL navigation, so useItems freshly re-reads the
+ * localItems index — same guarantee the old reload-then-open-panel shape gave.
+ */
 async function reloadIntoLibrary(page) {
-  await page.reload();
-  await expect(editorLocator(page)).toBeVisible({ timeout: 15_000 });
-  await page.locator('[data-testid="sidebar-library"]').click();
-  await expect(page.locator('[data-testid="library-panel"]')).toBeVisible({ timeout: 10_000 });
+  await gotoHome(page);
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -158,31 +171,31 @@ test('library lists local items and SearchInput filters them', async ({ page }) 
     dsl: 'GammaActor\nDeltaActor\nGammaActor->DeltaActor: gammaCall',
   });
 
-  // Reload so useItems re-reads the now-populated local index, then open Library.
+  // Navigate to the library (hub: the HomeView page) so useItems re-reads the
+  // now-populated local index.
   await reloadIntoLibrary(page);
 
-  // Both saved items appear as rows.
-  await expect(page.locator('[data-testid="library-list"]')).toBeVisible();
+  // Both saved items appear as cards in the home grid (hub PRs: library-list /
+  // lib-row-* became home-grid / home-card-* — see HomeView.tsx + DiagramCard.tsx).
+  await expect(page.locator('[data-testid="home-grid"]')).toBeVisible({ timeout: 10_000 });
   await expect(page.getByText('AlphaDiagram', { exact: true })).toBeVisible();
   await expect(page.getByText('GammaDiagram', { exact: true })).toBeVisible();
 
-  // Count the real item rows (exclude the per-row kebab menu testids).
-  const rowCount = await page.evaluate(() =>
-    Array.from(document.querySelectorAll('[data-testid^="lib-row-"]')).filter(
-      (el) => !el.getAttribute('data-testid')?.startsWith('lib-row-menu-'),
-    ).length,
-  );
-  expect(rowCount).toBe(2);
+  // Count the item cards (DiagramCard's only testid is home-card-<id> — the kebab
+  // trigger carries none, so a bare prefix count is exact).
+  await expect(page.locator('[data-testid^="home-card-"]')).toHaveCount(2);
 
-  // Type into the search field → list filters to the matching item only.
-  const search = page.locator('[data-testid="lib-search"]');
+  // Type into the search field → grid filters to the matching item only.
+  // (hub PRs: lib-search became home-search — same SearchInput component.)
+  const search = page.locator('[data-testid="home-search"]');
   await search.click();
   await search.pressSequentially('Alpha');
 
   await expect(page.getByText('AlphaDiagram', { exact: true })).toBeVisible();
   await expect(page.getByText('GammaDiagram', { exact: true })).toHaveCount(0);
 
-  // Clearing the search restores both rows.
+  // Clearing the search restores both cards (SearchInput's clear affordance kept
+  // its search-clear testid through the hub move).
   await page.locator('[data-testid="search-clear"]').click();
   await expect(page.getByText('AlphaDiagram', { exact: true })).toBeVisible();
   await expect(page.getByText('GammaDiagram', { exact: true })).toBeVisible();
@@ -210,6 +223,8 @@ test('export-all triggers a JSON file download', async ({ page }) => {
 
   // Clicking export-all builds a Blob and triggers a download (handleExportAll →
   // downloadText('zenuml-diagrams.json', …)). Assert the download event fires.
+  // (hub PRs: lib-export-all kept its testid but now lives in the HomeView
+  // header's ImportExportBar — the retired LibraryPanel no longer renders it.)
   const downloadPromise = page.waitForEvent('download', { timeout: 10_000 });
   await page.locator('[data-testid="lib-export-all"]').click();
   const download = await downloadPromise;
@@ -259,15 +274,18 @@ test('importing a JSON file adds a new library row', async ({ page }) => {
     ],
   });
 
-  // setInputFiles on the hidden file input — no fixture file needed.
+  // setInputFiles on the hidden file input — no fixture file needed. (hub PRs:
+  // lib-import-input kept its testid but now lives in the HomeView header's
+  // ImportExportBar.)
   await page.locator('[data-testid="lib-import-input"]').setInputFiles({
     name: 'import.json',
     mimeType: 'application/json',
     buffer: Buffer.from(payload, 'utf-8'),
   });
 
-  // handleImport calls itemService.saveItems (writes localItems) but does NOT
-  // reload — so the new row only appears after the next mount. Reload + reopen.
+  // handleImport calls itemService.saveItems (writes localItems). Re-navigate to
+  // the library so a fresh useItems mount reads the updated index — deterministic
+  // regardless of in-page subscription timing.
   await reloadIntoLibrary(page);
 
   await expect(page.getByText('ImportedDiagram', { exact: true })).toBeVisible();

--- a/e2e/tests/modals.spec.js
+++ b/e2e/tests/modals.spec.js
@@ -13,6 +13,7 @@
 
 import { test, expect } from '@playwright/test';
 import { suppressOneTimeModals } from './helpers/onetime';
+import { openEditor } from './helpers/hub';
 
 const THIRD_PARTY_ERROR_SOURCES = [
   'userscript.js', 'gtm.js', 'googletagmanager', 'google-analytics',
@@ -30,8 +31,10 @@ async function gotoFresh(page) {
   await suppressOneTimeModals(page);
   await page.goto('/');
   await page.evaluate(() => localStorage.clear());
-  await page.goto('/');
-  await expect(page.locator('[data-testid="dsl-editor"] .cm-content')).toBeVisible({ timeout: 15_000 });
+  // Hub (PRs #800/#801): '/' renders the HomeView library; all the modal triggers
+  // these tests drive live in the EDITOR's header menu — click through the hub's
+  // New CTA to reach it.
+  await openEditor(page);
 }
 
 /** Open an item in the header overflow menu by its trigger testid. */

--- a/e2e/tests/persistence.spec.js
+++ b/e2e/tests/persistence.spec.js
@@ -3,12 +3,18 @@
 //
 // Tests the local-persistence layer (localStorage) that survives page reloads
 // and across tabs — without any Firebase auth:
-//   1. last-code restore on reload (preserveLastCode default true)
+//   1. typed DSL survives a reload of the editor URL (hub re-ground — see test 1)
 //   2. per-page content is isolated across multi-page tabs
 //   3. "New" resets to the default starter DSL
+//
+// Hub (PRs #800/#801): bare '/' renders the HomeView library, so every test
+// reaches the editor through the hub's New CTA (openEditor) and the editor lives
+// at /?id=<uuid>. That URL shape changes WHICH boot branch a reload exercises —
+// see the test-1 comment.
 
 import { test, expect } from '@playwright/test';
 import { suppressOneTimeModals } from './helpers/onetime';
+import { openEditor } from './helpers/hub';
 
 // Default starter DSL, from web/src/state/editorStore.ts DEFAULT_STARTER.
 const STARTER_DSL_FRAGMENT = 'Alice -> Bob: Hello';
@@ -40,24 +46,24 @@ function isThirdPartyError(err) {
 }
 
 /**
- * Navigate to the app with a clean localStorage slate.
- * Uses a two-step approach: navigate to /empty-storage-sentinel (any path the
- * app serves — its own origin), clear localStorage, THEN go to '/'. This avoids
- * addInitScript which re-runs on every page.reload() and would wipe the storage
- * that the reload is supposed to read.
+ * Navigate to the EDITOR with a clean localStorage slate.
+ * Lands on the app origin first to clear storage, then clicks through the hub
+ * (openEditor) — this avoids addInitScript-based clearing, which re-runs on every
+ * page.reload() and would wipe the storage that the reload is supposed to read.
  */
 async function gotoFresh(page) {
   // M04: seed ONLY the one-time-modal flags (onboarded / lastSeenVersion) via an
   // init script so Onboarding/Support-pledge don't trap focus. This is safe with
   // this spec's reload-reads-storage approach: the init script ADDS two unrelated
-  // keys on each navigation but never touches the `code` slot the reload reads.
+  // keys on each navigation but never touches the item/`code` slots reloads read.
   await suppressOneTimeModals(page);
   // Step 1: land on the app origin so we can write to its localStorage.
   await page.goto('/');
   await page.evaluate(() => localStorage.clear());
-  // Step 2: reload — localStorage user-data is empty; the init script re-seeds only
-  // the one-time flags. We do NOT re-clear here.
-  await page.goto('/');
+  // Step 2: hub (PRs #800/#801) — '/' is the HomeView library; reach the editor
+  // through the New CTA. User data is empty; the init script re-seeds only the
+  // one-time flags. We do NOT re-clear here.
+  await openEditor(page);
 }
 
 /** Type a replacement DSL into the CM6 editor (select-all → Delete → type). */
@@ -76,9 +82,21 @@ function editorLocator(page) {
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
-// Test 1: Last-code restore on reload
+// Test 1: Typed DSL survives a page reload of the editor URL.
+//
+// HUB RE-GROUND (PRs #800/#801) — this used to be "last-code restore": reload at
+// '/' booted the preserveLastCode branch, which read localStorage['code'] back
+// into the editor. Under the hub the editor lives at /?id=<uuid> and bare '/'
+// renders the HomeView library, so the boot-time last-code READ branch
+// (resolveBootItem branch 3 — only reachable with NO ?id) can no longer be hit
+// from any editor URL on the web (verified live: reloading /?id= with an unsaved
+// item boots 'new' → starter DSL). The reload-persistence contract the user sees
+// is now: SAVE the diagram → reload /?id=<id> → boot getItem(id) restores the
+// local copy. This test follows that contract; the still-live last-code WRITE
+// path (visibilitychange/beforeunload → 'code' slot, REQ-PST) keeps its
+// assertion below so a regression in the write side stays visible.
 // ──────────────────────────────────────────────────────────────────────────────
-test('last-code restore: typed DSL persists across a page reload', async ({ page }) => {
+test('reload persistence: saved DSL is restored when the editor URL reloads', async ({ page }) => {
   page.on('pageerror', (err) => {
     if (isThirdPartyError(err)) return;
     throw err;
@@ -96,19 +114,15 @@ test('last-code restore: typed DSL persists across a page reload', async ({ page
   // Confirm the text landed in the editor before triggering the reload.
   await expect(editorLocator(page)).toContainText(UNIQUE_PARTICIPANT);
 
-  // Ensure last-code is written to localStorage. The AppRoot writes it on
-  // `beforeunload` AND on `visibilitychange` (document.hidden → true).
-  // Dispatch the visibilitychange event explicitly so the async write resolves
-  // before we check — the storage call is void-ed but localStorage.setItem is
-  // synchronous under localStore, so the value is available immediately after
-  // the event fires.
+  // REQ-PST write path (unchanged by the hub): AppRoot writes the last-code slot
+  // on `beforeunload` AND on `visibilitychange` (document.hidden → true).
+  // Dispatch visibilitychange explicitly and poll until localStorage['code']
+  // contains our token — keeps the write side guarded even though the web boot
+  // no longer reads it back at an editor URL (see header comment).
   await page.evaluate(() => {
     Object.defineProperty(document, 'hidden', { value: true, configurable: true });
     document.dispatchEvent(new Event('visibilitychange'));
   });
-
-  // Poll until localStorage['code'] contains our token — proves the write
-  // happened before we reload (handles any async wrapper overhead).
   await page.waitForFunction(
     (participant) => {
       const raw = localStorage.getItem('code');
@@ -119,8 +133,32 @@ test('last-code restore: typed DSL persists across a page reload', async ({ page
     { timeout: 5_000 },
   );
 
-  // Reload: boot reads localStorage['code'] (preserveLastCode=true by default)
-  // and restores the item — no addInitScript runs this time.
+  // Hub restore contract: SAVE the diagram so the reload's getItem(?id) finds the
+  // local copy. Save lives inside the header-menu dropdown; the FIRST signed-out
+  // save opens the one-time "Saved on this device" notice (fresh slate →
+  // loginAndSaveMessageSeen is false, so it shows with certainty) — dismiss it.
+  await page.locator('[data-testid="header-menu"]').click();
+  await page.locator('[data-testid="header-save"]').click();
+  const noticeCancel = page.locator('[data-testid="confirm-cancel"]');
+  await expect(noticeCancel).toBeVisible();
+  await noticeCancel.click();
+  await expect(noticeCancel).toBeHidden();
+
+  // Guard: poll until the item slot (keyed by the /?id= uuid) holds our token —
+  // proves the save landed before we reload.
+  const itemId = new URL(page.url()).searchParams.get('id');
+  expect(itemId, 'editor URL must carry ?id=<uuid> under the hub').toBeTruthy();
+  await page.waitForFunction(
+    ({ id, participant }) => {
+      const raw = localStorage.getItem(id);
+      return !!raw && raw.includes(participant);
+    },
+    { id: itemId, participant: UNIQUE_PARTICIPANT },
+    { timeout: 5_000 },
+  );
+
+  // Reload: boot resolves ?id= via getItem (signed-out → local copy) and restores
+  // the item — no addInitScript clearing runs this time.
   await page.reload();
 
   // Wait for the editor to re-hydrate with the restored content.

--- a/e2e/tests/production-build.spec.js
+++ b/e2e/tests/production-build.spec.js
@@ -9,6 +9,7 @@ test.beforeEach(() => {
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 import { PREVIEW_PORT } from '../../playwright.config.js';
+import { openEditor } from './helpers/hub.js';
 
 // Production-build asset proof (M00 shim build-path). Runs against the STATIC
 // built output (web/dist) served by `vite preview` on PREVIEW_PORT — NOT the dev
@@ -54,20 +55,11 @@ test('built app renders the diagram with no dev-only /@fs/ URL and a 200 core as
     if (/\/assets\/zenuml-.*\.js$/.test(r.url())) coreAssetStatus = r.status();
   });
 
-  await page.goto(PREVIEW_URL);
-
-  // Hub routing: "/" shows the HomeView (library) when no diagram id is in the URL.
-  // Navigate into the editor so the preview-iframe is present.
-  const homeView = page.locator('[data-testid="home-view"]');
-  if (await homeView.isVisible({ timeout: 3_000 }).catch(() => false)) {
-    const emptyCta = page.locator('[data-testid="home-empty-new"]');
-    const headerNew = page.locator('[data-testid="home-new"]');
-    if (await emptyCta.isVisible({ timeout: 1_000 }).catch(() => false)) {
-      await emptyCta.click();
-    } else {
-      await headerNew.click();
-    }
-  }
+  // Hub routing: "/" shows the HomeView (library) when no diagram id is in the
+  // URL. openEditor (shared helper) clicks through the New CTA so the editor +
+  // preview-iframe are present. The request/response listeners above are attached
+  // BEFORE this navigation, so the asset assertions still see every request.
+  await openEditor(page, { url: PREVIEW_URL });
 
   // The diagram must render from the BUILT bundle.
   const mount = page

--- a/e2e/tests/smoke.spec.js
+++ b/e2e/tests/smoke.spec.js
@@ -1,10 +1,14 @@
 import { test, expect } from '@playwright/test';
 import { suppressOneTimeModals } from './helpers/onetime';
+import { openEditor } from './helpers/hub';
 
 // Smoke: the NEW app (web/) loads, the editor + preview shells are present, and
 // the preview iframe's srcdoc carries the @zenuml/core mount point. This proves
 // the app boots and the iframe scaffolding is in place — the dsl-spot-check spec
 // proves the editor -> postMessage -> @zenuml/core render path renders an SVG.
+//
+// Hub (PRs #800/#801): '/' renders the HomeView library, not the editor — the
+// editor smokes click through the hub's New CTA via openEditor().
 
 // Deployed sites (staging/prod, reached via PW_BASE_URL) load third-party
 // analytics/CDN scripts (GTM, Cloudflare Zaraz, Clarity, Paddle) that throw
@@ -36,7 +40,15 @@ test.beforeEach(async ({ page }) => {
     throw err;
   });
   await suppressOneTimeModals(page); // M04: keep onboarding/pledge from trapping focus
+  // Hub: '/' is the HomeView library; reach the editor through the New CTA.
+  await openEditor(page);
+});
+
+test("'/' renders the HomeView hub library @smoke", async ({ page }) => {
+  // Hub (PRs #800/#801): bare '/' is the library page. Re-navigate there (the
+  // beforeEach clicked through into the editor) and assert the hub surface.
   await page.goto('/');
+  await expect(page.locator('[data-testid="home-view"]')).toBeVisible();
 });
 
 test('app loads with editor and preview iframe @smoke', async ({ page }) => {
@@ -45,10 +57,14 @@ test('app loads with editor and preview iframe @smoke', async ({ page }) => {
 });
 
 test('preview iframe carries the @zenuml/core mounting point @smoke', async ({ page }) => {
-  // CodeMirror 6 editable surface is mounted and shows non-empty default text.
+  // CodeMirror 6 editable surface is mounted and editable. Hub (PRs #800/#801):
+  // the hub's New CTA seeds a BLANK diagram by design (handleNewDiagramFromHome
+  // loads js: ''), so the old "shows non-empty default text" assertion no longer
+  // matches the product — the DEFAULT_STARTER text now only appears via the
+  // in-editor New action (covered by persistence.spec.js test 3).
   const editorContent = page.locator('[data-testid="dsl-editor"] .cm-content');
   await expect(editorContent).toBeVisible();
-  await expect(editorContent).not.toBeEmpty();
+  await expect(editorContent).toHaveAttribute('contenteditable', 'true');
 
   // The preview is a srcdoc iframe; #mounting-point is the fixed scaffold that
   // @zenuml/core renders into. Assert it is ATTACHED (an empty mount div can be


### PR DESCRIPTION
## Summary
Master run 27269219536 failed its staging E2E gate after #816: the root specs still asserted the pre-hub UI ('/' = editor, sidebar rail). Hub PRs #800/#801 had only adapted production-build.spec.js. This PR adapts the rest: shared openEditor/gotoHome helpers, embed CONTROL re-grounded on editor-region (rail removed by f023f89), library spec re-targeted to HomeView (cards/search/header import-export), persistence boot contract re-grounded (probe-verified), smoke pins '/' = hub.

## Test plan
- Root suite local x2: 24 passed / 0 failed (dev-server shape); 22 passed + 2 by-design skips (CI PW_BASE_URL shape) x2
- Spec/test changes only — no product source

🤖 Generated with [Claude Code](https://claude.com/claude-code)