### PR TITLE
fix(web): restore legacy static pages (help.html, privacy-policy, EULA) after the web/dist cutover

### DIFF
--- a/e2e/tests/production-build.spec.js
+++ b/e2e/tests/production-build.spec.js
@@ -4,7 +4,10 @@ import { existsSync, readdirSync } from 'fs';
 // These tests check the LOCAL web/dist build and hit localhost:PREVIEW_PORT directly.
 // They must not run when PW_BASE_URL targets a remote host (staging/prod gate).
 test.beforeEach(() => {
-  test.skip(!!process.env.PW_BASE_URL, 'production-build checks require a local web/dist build');
+  test.skip(
+    !!process.env.PW_BASE_URL,
+    'production-build checks require a local web/dist build',
+  );
 });
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
@@ -24,7 +27,8 @@ import { openEditor } from './helpers/hub.js';
 // Requires `pnpm -C web build` first (the webServer preview entry serves web/dist).
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const DIST_ASSETS = resolve(__dirname, '../../web/dist/assets');
+const DIST = resolve(__dirname, '../../web/dist');
+const DIST_ASSETS = resolve(DIST, 'assets');
 const PREVIEW_URL = `http://localhost:${PREVIEW_PORT}/`;
 
 test('built dist contains a hashed @zenuml/core asset on disk', async () => {
@@ -32,11 +36,84 @@ test('built dist contains a hashed @zenuml/core asset on disk', async () => {
     existsSync(DIST_ASSETS),
     `web/dist/assets is missing — run "pnpm -C web build" before this spec.\n${DIST_ASSETS}`,
   ).toBe(true);
-  const zenumlAssets = readdirSync(DIST_ASSETS).filter((f) => /^zenuml-.*\.js$/.test(f));
+  const zenumlAssets = readdirSync(DIST_ASSETS).filter((f) =>
+    /^zenuml-.*\.js$/.test(f),
+  );
   expect(
     zenumlAssets.length,
     `Expected a hashed assets/zenuml-*.js in the build output (the shim's emitFile).\nFound: ${readdirSync(DIST_ASSETS).join(', ')}`,
   ).toBeGreaterThan(0);
+});
+
+// Cutover regression guard (M05): hosting.public → web/dist dropped the legacy
+// static pages that the old `app/` assembly served (help.html + help/ assets, and
+// the privacy-policy / EULA legal pages). help.html is linked from the in-app
+// HelpModal (www → zenuml.com → app.zenuml.com/help.html) and bookmarks; the legal
+// pages are linked from the Chrome Web Store / Marketplace listings. All must keep
+// 200-ing. The vite copy-legacy-static-pages plugin re-emits them into the build.
+test('built dist serves the legacy /help.html page and its assets', async ({
+  page,
+}) => {
+  // (a) help.html + the relatively-referenced help/ assets exist on disk.
+  expect(
+    existsSync(resolve(DIST, 'help.html')),
+    'web/dist/help.html missing — the copy-legacy-static-pages vite plugin regressed (app.zenuml.com/help.html would 404)',
+  ).toBe(true);
+  for (const asset of [
+    'help/stylesheets/screen.css',
+    'help/javascripts/all.js',
+    'help/images/logo.png',
+  ]) {
+    expect(
+      existsSync(resolve(DIST, asset)),
+      `web/dist/${asset} missing — help.html references it relatively`,
+    ).toBe(true);
+  }
+
+  // (b) it is actually served (200) from the static preview, as Firebase Hosting would.
+  const resp = await page.goto(`${PREVIEW_URL}help.html`);
+  expect(
+    resp?.status(),
+    'GET /help.html must return 200 from the built dist',
+  ).toBe(200);
+  // The slate page's all.js rewrites document.title to "<section> – ZenUML
+  // language Reference" on load, so match the stable suffix rather than the exact
+  // string.
+  await expect(page).toHaveTitle(/ZenUML language Reference$/);
+});
+
+// The legal pages (privacy policy + EULA) are linked from external store/
+// marketplace listings, so their exact prior URLs must keep resolving. Served at
+// their original paths: /privacy-policy/privacy-policy.html (the dir holds no
+// index.html) and /End-User-License-Agreement/ (index.html → directory index).
+test('built dist serves the legacy privacy-policy and EULA legal pages', async ({
+  page,
+}) => {
+  for (const [file, url, titleRe] of [
+    [
+      'privacy-policy/privacy-policy.html',
+      'privacy-policy/privacy-policy.html',
+      /ZenUML Privacy Policy/,
+    ],
+    [
+      'End-User-License-Agreement/index.html',
+      'End-User-License-Agreement/',
+      /End User License Agreement/i,
+    ],
+  ]) {
+    expect(
+      existsSync(resolve(DIST, file)),
+      `web/dist/${file} missing — copy-legacy-static-pages regressed (the listing URL would 404)`,
+    ).toBe(true);
+    const resp = await page.goto(`${PREVIEW_URL}${url}`);
+    expect(
+      resp?.status(),
+      `GET /${url} must return 200 from the built dist`,
+    ).toBe(200);
+    await expect(page.locator('body')).toContainText(
+      titleRe instanceof RegExp ? titleRe : String(titleRe),
+    );
+  }
 });
 
 test('built app renders the diagram with no dev-only /@fs/ URL and a 200 core asset', async ({
@@ -76,6 +153,9 @@ test('built app renders the diagram with no dev-only /@fs/ URL and a 200 core as
 
   // The @zenuml/core asset must have been served successfully (200), proving the
   // built bundle references the emitted hashed asset rather than a broken path.
-  expect(coreAssetStatus, 'Expected the zenuml-*.js core asset to be requested').not.toBeNull();
+  expect(
+    coreAssetStatus,
+    'Expected the zenuml-*.js core asset to be requested',
+  ).not.toBeNull();
   expect(coreAssetStatus).toBe(200);
 });

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
-import { readFileSync } from 'fs';
+import { readFileSync, cpSync, existsSync } from 'fs';
 import { assetsInlineLimit } from './src/preview/assetInlining';
 import { configDefaults } from 'vitest/config';
 
@@ -28,16 +28,60 @@ const zenumlAssetUrlShim = {
     zenumlShimIsBuild = config.command === 'build';
   },
   resolveId(source: string) {
-    return source === '@zenuml/core/dist/zenuml?url' ? '\0zenuml-core-asset-url' : null;
+    return source === '@zenuml/core/dist/zenuml?url'
+      ? '\0zenuml-core-asset-url'
+      : null;
   },
   load(this: any, id: string) {
     if (id !== '\0zenuml-core-asset-url') return null;
-    const filePath = resolve(__dirname, 'node_modules/@zenuml/core/dist/zenuml.js');
+    const filePath = resolve(
+      __dirname,
+      'node_modules/@zenuml/core/dist/zenuml.js',
+    );
     if (zenumlShimIsBuild) {
-      const ref = this.emitFile({ type: 'asset', name: 'zenuml.js', source: readFileSync(filePath) });
+      const ref = this.emitFile({
+        type: 'asset',
+        name: 'zenuml.js',
+        source: readFileSync(filePath),
+      });
       return `export default import.meta.ROLLUP_FILE_URL_${ref};`;
     }
     return `export default ${JSON.stringify('/@fs' + filePath)};`;
+  },
+};
+
+// The M05 cutover repointed Firebase hosting.public from the legacy `app/`
+// assembly to `web/dist`. The legacy build copied a handful of static pages into
+// app/, served at app.zenuml.com/<page>; the cutover dropped them (now 404):
+//   help.html (+ help/ assets) — in-app HelpModal link (www → zenuml.com →
+//     app.zenuml.com/help.html) and external bookmarks. help.html references
+//     help/stylesheets, help/images, help/javascripts relatively, so the whole
+//     help/ dir ships with it.
+//   privacy-policy/ (privacy-policy.html) and End-User-License-Agreement/
+//     (index.html) — legal pages linked from the Chrome Web Store / Marketplace
+//     listings (no in-app link), so they must keep resolving at their prior URLs.
+// Copy the repo-root sources into dist at build time (the root files stay the
+// single source of truth — no duplication into web/public/). Regression-guarded
+// by e2e/tests/production-build.spec.js. Build-only; runs after the bundle is
+// written (emptyOutDir has already run, so nothing clobbers these). cpSync copies
+// files and directories alike (recursive).
+const LEGACY_STATIC_PAGES = [
+  'help.html',
+  'help',
+  'privacy-policy',
+  'End-User-License-Agreement',
+];
+const copyLegacyStaticPages = {
+  name: 'copy-legacy-static-pages',
+  apply: 'build' as const,
+  closeBundle() {
+    const repoRoot = resolve(__dirname, '..');
+    const outDir = resolve(__dirname, 'dist');
+    for (const entry of LEGACY_STATIC_PAGES) {
+      const src = resolve(repoRoot, entry);
+      if (existsSync(src))
+        cpSync(src, resolve(outDir, entry), { recursive: true });
+    }
   },
 };
 
@@ -53,7 +97,7 @@ const proxy = (path: string, fn: string) => ({
 });
 
 export default defineConfig({
-  plugins: [zenumlAssetUrlShim, react()],
+  plugins: [zenumlAssetUrlShim, copyLegacyStaticPages, react()],
   // Conventional layout: root = web/ (this dir), index.html at web/index.html,
   // source under web/src, build output to web/dist. (Differs from the legacy
   // app's root:'src' quirk — this is a clean self-contained project.)


### PR DESCRIPTION
## Summary

The M05 cutover repointed Firebase `hosting.public` from the legacy `app/` assembly to `web/dist`. The old `app/` build copied a set of static pages into the deploy root; the cutover dropped them, so on production they now **404**:

- `app.zenuml.com/help.html` (+ its `help/` assets) — linked from the in-app **HelpModal** ("Documentation & help" → `www.zenuml.com/help.html` → `zenuml.com/help.html` → `app.zenuml.com/help.html`) and external bookmarks.
- `app.zenuml.com/privacy-policy/privacy-policy.html` — Privacy Policy (linked from Chrome Web Store / Marketplace listings).
- `app.zenuml.com/End-User-License-Agreement/` — EULA / Terms (same listings).

### Fix

A small build-only Vite plugin (`copy-legacy-static-pages` in `web/vite.config.ts`) copies the repo-root sources into `web/dist` at build time. The root files stay the single source of truth — no duplication into `web/public/`. `cpSync` handles both the `help.html` file and the `help/`, `privacy-policy/`, `End-User-License-Agreement/` directories.

### Regression guard

`e2e/tests/production-build.spec.js` (already run on PRs via `deploy-staging.yml`) gains two tests asserting each page exists in `dist` **and** is served `200` from `vite preview` (as Firebase Hosting would).

## Test plan

- `pnpm -C web build` → confirmed `dist/help.html`, `dist/help/*`, `dist/privacy-policy/privacy-policy.html`, `dist/End-User-License-Agreement/index.html` all emitted.
- `npx playwright test production-build --project=chromium` → **4/4 green** (the 2 existing asset specs + 2 new legacy-page specs).
- `pnpm -C web typecheck` → clean.
- Legacy root `yarn build` → green (unaffected; change is isolated to `web/`).

## Files changed

- `web/vite.config.ts` — `copy-legacy-static-pages` build plugin.
- `e2e/tests/production-build.spec.js` — serve-200 regression guards for help/privacy/EULA.