### PR TITLE
test(e2e): execute gap plan — 57 new specs across 12 areas + cloud scaffold

### DIFF
--- a/e2e/E2E_GAP_TEST_PLAN.md
+++ b/e2e/E2E_GAP_TEST_PLAN.md
@@ -1,0 +1,268 @@
+# E2E Gap Test Plan — features not yet covered by Playwright
+
+**Purpose.** The editor/DSL language is exhaustively covered (≈250 tests in
+`web/e2e/`: completion, snippets, indentation, brackets, highlighting). The
+app-level surface (auth, sharing, subscription, settings depth, preview controls,
+library actions, export variants, mobile) is thinly covered by the root
+`e2e/tests/` staging-gate suite. This plan enumerates the **uncovered** behaviors
+and a test for each, so the suite can grow to cover the whole product.
+
+**Already covered (do NOT re-plan):** editor typing/completion/snippets/indent/
+highlight (`catalog*`, `editor-language`, `typing-mechanics`); DSL→SVG render
+(`dsl-spot-check`, `smoke`); embed-by-value `?code` + open-in-app + shortcuts-off
+(`embed`); library list/search/export-all/import-JSON (`library`); multi-page
+add/switch + last-code restore + New-resets (`persistence`); modal **open** +
+one action for Settings(font-size)/Create-New/Help/Cheat-Sheet/Shortcuts/Pricing
+(`modals`); Report-a-bug FAB→modal→GitHub URL (`report-bug`); routing
+editor-as-landing + `?view=diagrams` (`smoke`).
+
+## Legend
+
+**Dependency** — what infra a test needs (drives where it can run):
+- `UI` — pure browser, no backend. Runs today (local dev + staging gate).
+- `AUTH` — needs a signed-in session (Firebase Auth emulator or a seeded test account).
+- `CLOUD` — needs Firestore + cloud functions (`create-share`, `sync-diagram`, `get-shared-item`) — emulator.
+- `PADDLE` — needs Paddle sandbox or a mocked `usePaddle`.
+- `MOBILE` — needs Playwright viewport/device emulation (no backend).
+
+**Priority** — `P0` core journey, `P1` important, `P2` edge/polish.
+
+**Note on infra.** Most `AUTH`/`CLOUD`/`PADDLE` cases are why these gaps exist —
+the staging gate runs signed-out against a live deploy. Recommended unlock:
+stand up the **Firebase emulator suite** (auth + firestore + functions) for a
+new `e2e/tests/*.cloud.spec.js` project, and mock Paddle's `openCheckout`. Unit
+coverage already exists for the services (`useShare`, `subscriptionService`,
+`exportImport`, `folderService`, …) — these e2e cases target the **UI + wiring**,
+not the pure logic.
+
+---
+
+## 1. CSS editor & custom-CSS gate
+
+| ID | Behavior | Method | Dep | Pri |
+|----|----------|--------|-----|-----|
+| CSS-1 | CSS pane expands/collapses ("Custom CSS · click to expand" footer) | Click footer; assert CSS CodeMirror surface visible/hidden | UI | P1 |
+| CSS-2 | CSS mode select offers CSS/SCSS/Sass/Less/Stylus/ACSS | Open mode select; assert all 6 options | UI | P1 |
+| CSS-3 | SCSS/Less/Stylus source transpiles → preview reflects compiled CSS | Enter `$c:red; .label{color:$c}` (scss); assert preview label color | UI | P1 |
+| CSS-4 | ACSS mode reveals the Atomic-CSS settings entry; opens `AtomicCssSettingsModal` | Switch mode→acss; click settings; assert modal | UI | P2 |
+| CSS-5 | Non-plain CSS mode gated behind Plus for signed-out/free users (→ pricing) | Switch to scss while free; assert pricing/upgrade prompt (`cssGated`) | AUTH | P1 |
+| CSS-6 | Prettier-format CSS (Ctrl+Shift+F) reformats the CSS buffer | Type minified CSS; press shortcut; assert formatted | UI | P2 |
+
+## 2. Preview controls
+
+| ID | Behavior | Method | Dep | Pri |
+|----|----------|--------|-----|-----|
+| PRV-1 | Present/fullscreen toggle expands diagram, hides editor/console; Exit restores | Click Present; assert editor hidden + fullscreen surface; Exit; assert restored | UI | P0 |
+| PRV-2 | Debug console toggles open/closed; shows render output | Toggle console; assert panel; assert "No issues" / entries | UI | P1 |
+| PRV-3 | Ctrl+L clears the console | Produce entries; Ctrl+L; assert console emptied | UI | P2 |
+| PRV-4 | Console eval runs JS against preview iframe and returns a result | Type expression in console input; assert echoed result | UI | P2 |
+| PRV-5 | Mobile (<768px, non-fullscreen) renders native **SVG** (fit-to-width), not fixed-px HTML | Emulate phone; assert `#svg-mount` svg present, width:100% | MOBILE | P1 |
+| PRV-6 | Auto-preview off → edits do NOT re-render until manual refresh | Disable auto-preview (settings); edit; assert preview stale until refresh | UI | P2 |
+| PRV-7 | Refresh-on-resize setting re-renders on window resize | Enable; resize viewport; assert re-render | UI | P2 |
+| PRV-8 | Zoom indicator shows 100% (presentational) | Assert renderer header shows `100%` | UI | P2 |
+
+## 3. Multi-page (beyond add/switch)
+
+| ID | Behavior | Method | Dep | Pri |
+|----|----------|--------|-----|-----|
+| PG-1 | Rename page inline (double-click tab / menu) commits new title | Double-click page tab; type; blur; assert tab label | UI | P1 |
+| PG-2 | Delete non-default page shows confirm, removes the page | Add page; delete; confirm; assert tab gone + active page falls back | UI | P1 |
+| PG-3 | Default (first) page cannot be deleted (no delete affordance) | Assert page 1 has no delete control | UI | P2 |
+| PG-4 | Page metadata edits mark the item dirty (drive autosave) | Rename page; assert unsaved indicator | UI | P2 |
+
+## 4. Library / Hub actions
+
+| ID | Behavior | Method | Dep | Pri |
+|----|----------|--------|-----|-----|
+| LIB-1 | Card kebab → **Duplicate** creates a copy row | Seed item; kebab→Duplicate; gotoHome; assert 2 rows | UI | P1 |
+| LIB-2 | Card kebab → **Delete** removes the row (with confirm if any) | Seed item; kebab→Delete; assert row gone | UI | P0 |
+| LIB-3 | Card kebab → **Export as HTML** downloads a standalone file | kebab→Export HTML; assert download `*.html` | UI | P1 |
+| LIB-4 | Sort toggle (Updated ↔ Title A–Z) reorders the grid | Seed items with known titles/dates; toggle sort; assert order | UI | P2 |
+| LIB-5 | Card shows DSL preview (≤240 chars), title, last-updated date | Seed; assert card body contains DSL snippet + date | UI | P2 |
+| LIB-6 | "New diagram" CTA from hub opens a blank editor | Click home-new; assert editor with starter/blank | UI | P1 |
+| LIB-7 | Signed-out hub shows a sign-in affordance | gotoHome signed-out; assert sign-in prompt visible | UI | P2 |
+| LIB-8 | Empty-state ("No diagrams yet") shows New + Browse templates | Fresh hub; assert empty-state CTAs | UI | P1 |
+
+## 5. Folders
+
+| ID | Behavior | Method | Dep | Pri |
+|----|----------|--------|-----|-----|
+| FLD-1 | Create folder; it appears in the folder list with 0 count | Create folder "Work"; assert listed, count 0 | AUTH/CLOUD | P1 |
+| FLD-2 | Move a diagram into a folder; folder count increments; "Unfiled" decrements | Drag/menu-move item; assert counts | AUTH/CLOUD | P1 |
+| FLD-3 | Rename folder | Rename; assert new label | AUTH/CLOUD | P2 |
+| FLD-4 | Delete folder; its items return to Unfiled | Delete; assert items unfiled | AUTH/CLOUD | P2 |
+| FLD-5 | "All" vs "Unfiled" filters the grid | Click each; assert filtered set | AUTH/CLOUD | P1 |
+
+> Verify whether folders are local-only (then `UI`) or cloud-backed (`CLOUD`) — `useFolders.ts`/`folderService.ts`.
+
+## 6. Templates
+
+| ID | Behavior | Method | Dep | Pri |
+|----|----------|--------|-----|-----|
+| TPL-1 | "Browse templates" opens the full `CreateNewModal` picker | Hub→Browse templates; assert modal grid | UI | P1 |
+| TPL-2 | Each template (Basic, B&W, Blue, starUML, Blank) loads its DSL+CSS and opens editor | For each card: select; assert editor DSL matches template | UI | P1 |
+| TPL-3 | Template previews render the schematic CSS thumbnail | Assert each card shows a styled preview | UI | P2 |
+
+## 7. Settings (beyond font-size)
+
+| ID | Behavior | Method | Dep | Pri |
+|----|----------|--------|-----|-----|
+| SET-1 | Editor **theme** change applies live to CodeMirror | Change theme; assert `.cm-editor` theme class/colors change | UI | P1 |
+| SET-2 | **Keymap = Vim** enables Vim bindings (e.g. `i`/`Esc` modal editing) | Set vim; assert vim status / modal behavior in editor | UI | P1 |
+| SET-3 | **Font family** change applies to `.cm-content` | Change family; assert computed font-family | UI | P2 |
+| SET-4 | **Indent** unit (2/4/8/tabs) changes auto-indent width | Set indent=4; Enter in block; assert 4-space indent | UI | P1 |
+| SET-5 | Behavior toggles (line-wrap, auto-close, autocomplete, auto-save) take effect | Toggle each; assert observable effect | UI | P1 |
+| SET-6 | Settings persist across reload (local syncStore) | Change; reload; assert retained | UI | P1 |
+| SET-7 | Signed-in: settings persist to cloud and survive a fresh session | AUTH; change; re-login elsewhere; assert retained | AUTH/CLOUD | P2 |
+| SET-8 | "Replace new tab" toggle hidden on web (extension-only) | Assert control absent in web context | UI | P2 |
+
+## 8. Persistence / autosave (beyond last-code)
+
+| ID | Behavior | Method | Dep | Pri |
+|----|----------|--------|-----|-----|
+| PST-1 | Auto-save 15s loop fires only when enabled AND dirty | Enable; edit; wait; assert save occurs; clean → no save | UI/AUTH | P1 |
+| PST-2 | Save indicator transitions Unsaved → Saving… → Saved (signed-in) | AUTH; edit→save; assert state labels | AUTH | P1 |
+| PST-3 | Read-only (shared) item: Save disabled, Fork offered | Open read-only; assert Save disabled + Fork present | CLOUD | P1 |
+| PST-4 | Read-only item is NOT written to the last-code slot (no stale re-boot) | Open read-only; reload `/`; assert NOT the shared item | CLOUD | P2 |
+| PST-5 | preserve-last-code = off → reload `/` shows starter, not last edit | Disable setting; edit; reload; assert starter | UI | P2 |
+
+## 9. Authentication
+
+| ID | Behavior | Method | Dep | Pri |
+|----|----------|--------|-----|-----|
+| AUTH-1 | Sign-in modal lists Google/GitHub/Facebook/Twitter providers | Open login; assert 4 provider buttons | UI | P1 |
+| AUTH-2 | Google sign-in completes → profile menu shows name/photo/plan | AUTH emulator; sign in; assert ProfileMenu | AUTH | P0 |
+| AUTH-3 | Last-used provider re-surfaces as elevated/primary on next login | Sign in (GitHub); sign out; reopen; assert GitHub primary + chip | AUTH | P2 |
+| AUTH-4 | Auth error surfaces in the modal alert | Force provider error; assert error text | AUTH | P2 |
+| AUTH-5 | Login modal auto-dismisses once auth resolves | Sign in; assert modal closes (P5 regression) | AUTH | P1 |
+| AUTH-6 | Sign-out clears session, returns to editor/hub, hides profile menu | Sign out; assert signed-out chrome | AUTH | P1 |
+
+## 10. Import-on-login
+
+| ID | Behavior | Method | Dep | Pri |
+|----|----------|--------|-----|-----|
+| IOL-1 | First sign-in with local diagrams offers `AskToImportModal` | Seed locals; sign in; assert import prompt | AUTH | P1 |
+| IOL-2 | Accepting import uploads local items to the cloud account | Accept; assert items present after reload signed-in | AUTH/CLOUD | P1 |
+| IOL-3 | Declining keeps locals untouched, no upload | Decline; assert no cloud write | AUTH/CLOUD | P2 |
+
+## 11. Sharing
+
+| ID | Behavior | Method | Dep | Pri |
+|----|----------|--------|-----|-----|
+| SHR-1 | Share button: anonymous → opens sign-in first | Signed-out; click Share; assert login modal | AUTH | P1 |
+| SHR-2 | Create share link → popover shows `?id=&share-token=` URL | AUTH; Share; assert URL in popover | CLOUD | P0 |
+| SHR-3 | Copy button copies URL and shows "Copied ✓" | Click copy; assert confirmation + clipboard | CLOUD | P1 |
+| SHR-4 | Stop-sharing revokes the token | Stop sharing; assert link no longer resolves | CLOUD | P2 |
+| SHR-5 | Opening a share URL renders the diagram **read-only** + "Open in ZenUML" | Visit share URL; assert read-only render + link | CLOUD | P0 |
+| SHR-6 | Fork a shared item → owned editable copy (clears readonly/shareToken) | Open shared; Fork; assert editable + new id | CLOUD | P1 |
+| SHR-7 | Bad share link → `ShareErrorNotice` with "Start fresh" | Visit bad token; assert error modal | CLOUD | P2 |
+| SHR-8 | Share button disabled for read-only items | Open read-only; assert Share disabled | CLOUD | P2 |
+
+## 12. Export / Import (beyond export-all / import-JSON)
+
+| ID | Behavior | Method | Dep | Pri |
+|----|----------|--------|-----|-----|
+| EXP-1 | Export PNG downloads a `.png` of the diagram | Trigger PNG export (preview menu); assert download | UI | P1 |
+| EXP-2 | Export SVG downloads an `.svg` | Trigger SVG export; assert download | UI | P1 |
+| EXP-3 | Export-as-HTML produces a self-contained file that renders standalone | Export HTML; open file; assert diagram renders (CDN core) | UI | P1 |
+| EXP-4 | Import of malformed JSON shows an error dialog (not silent) | Import bad file; assert error modal | UI | P1 |
+| EXP-5 | Import merge skips duplicate IDs; reports added count | Import overlapping set; assert only new rows added | UI | P2 |
+
+## 13. Subscription / pricing
+
+| ID | Behavior | Method | Dep | Pri |
+|----|----------|--------|-----|-----|
+| SUB-1 | Pricing modal shows 4 tiers (Starter/Basic/Plus/Enterprise) | Open pricing; assert tiers | UI | P1 |
+| SUB-2 | Upgrade (signed-in) opens Paddle checkout for the chosen plan | AUTH; click Upgrade; assert `openCheckout(plan)` | PADDLE | P1 |
+| SUB-3 | Upgrade (anonymous) → sign-in → resumes checkout for the captured plan | Signed-out Upgrade; sign in; assert checkout resumes (`5751479`) | AUTH/PADDLE | P1 |
+| SUB-4 | Plan-limit at save: free user over 3 diagrams → limit notice + "Free Limit" event; local copy kept, cloud write withheld | AUTH free; exceed cap; save; assert notice + no cloud write | AUTH/CLOUD | P0 |
+| SUB-5 | "Manage subscription" link present for paid users (Paddle cancel URL) | AUTH plus; assert manage link | AUTH | P2 |
+| SUB-6 | Plus-only features show the Plus badge (informational) | Assert badge on gated settings | UI | P2 |
+
+## 14. Header / title / actions
+
+| ID | Behavior | Method | Dep | Pri |
+|----|----------|--------|-----|-----|
+| HDR-1 | Inline title edit: click → focus, type, Enter commits | Edit title; assert committed | UI | P1 |
+| HDR-2 | Title edit Escape cancels (reverts) | Type; Escape; assert original | UI | P2 |
+| HDR-3 | Unsaved marker (`*`/`•`) appears on edit, clears on save | Edit; assert marker; save; assert cleared | UI/AUTH | P1 |
+| HDR-4 | Fork button duplicates current item into an owned copy | Click Fork; assert new editable item | CLOUD | P2 |
+| HDR-5 | Breadcrumb "← Your diagrams" returns to the hub | Click breadcrumb; assert `?view=diagrams` hub | UI | P1 |
+| HDR-6 | Signed-out header shows "Sign in"; signed-in shows profile menu | Toggle auth; assert correct affordance | AUTH | P1 |
+
+## 15. Keyboard shortcuts (beyond Cmd+Shift+?)
+
+| ID | Behavior | Method | Dep | Pri |
+|----|----------|--------|-----|-----|
+| KB-1 | Cmd/Ctrl+S triggers a save | Edit; press save; assert save fired | UI/AUTH | P1 |
+| KB-2 | Ctrl+L clears the console | (see PRV-3) | UI | P2 |
+| KB-3 | Editor find/replace/comment/format shortcuts work (smoke) | Exercise one of each via keymap | UI | P2 |
+
+## 16. Embed (beyond by-value)
+
+| ID | Behavior | Method | Dep | Pri |
+|----|----------|--------|-----|-----|
+| EMB-1 | Embed by-reference `?embed&id=&share-token=` renders the shared diagram | CLOUD; visit; assert embed render | CLOUD | P1 |
+| EMB-2 | Embed empty state ("Diagram unavailable") on bad `?code`/bad token | Visit bad embed; assert empty-state + open-in-app | UI/CLOUD | P1 |
+| EMB-3 | Embed posts content-size to parent (responsive iframe sizing) | Listen for postMessage dimensions; assert message | UI | P2 |
+| EMB-4 | Legacy JSON-encoded `?code=` (not bare DSL) still renders | Visit legacy ?code; assert render | UI | P2 |
+
+## 17. Modals (uncovered / deeper)
+
+| ID | Behavior | Method | Dep | Pri |
+|----|----------|--------|-----|-----|
+| MOD-1 | Onboarding modal shows once per profile (localStorage `onboarded`) | Fresh profile; assert modal; reload; assert gone | UI | P1 |
+| MOD-2 | Support-Pledge modal shows when app.version > lastSeenVersion, once | Bump version; assert modal; reload; assert gone | UI | P2 |
+| MOD-3 | Only one modal open at a time (opening a 2nd closes the 1st) | Open Settings then Help; assert Settings closed | UI | P1 |
+| MOD-4 | Help modal links (Docs/Contact/GitHub) have correct hrefs + new-tab | Assert href + target=_blank rel=noopener | UI | P2 |
+| MOD-5 | Cheat-sheet lists all documented rows (participant…comment) | Assert each example row present | UI | P2 |
+| MOD-6 | Shortcuts modal lists global + editor shortcut groups | Assert both sections | UI | P2 |
+| MOD-7 | Login modal opens from header "Sign in" and from gated actions | Trigger both; assert modal | UI | P1 |
+
+## 18. Mobile / responsive
+
+| ID | Behavior | Method | Dep | Pri |
+|----|----------|--------|-----|-----|
+| MOB-1 | Mobile: segmented control toggles Editor ↔ Preview panes | Phone viewport; toggle; assert active pane | MOBILE | P1 |
+| MOB-2 | Mobile hub header is two-row; collapses to one row at sm+ | Phone vs sm; assert layout | MOBILE | P2 |
+| MOB-3 | Action buttons go icon-only on mobile (text hidden) | Phone; assert Share/Present icon-only | MOBILE | P2 |
+| MOB-4 | Modals fit the viewport and scroll (no overflow) on small screens | Phone; open a tall modal; assert contained | MOBILE | P2 |
+
+## 19. Analytics / telemetry
+
+| ID | Behavior | Method | Dep | Pri |
+|----|----------|--------|-----|-----|
+| ANL-1 | `landed_in_editor{bootKind}` fires once per editor boot | Intercept analytics; boot; assert one event w/ label | UI | P1 |
+| ANL-2 | `hub_opened{source}` fires on hub arrival; re-arms on Back | Open hub via param then breadcrumb/Back; assert correct labels | UI | P1 |
+| ANL-3 | `first_edit` fires once per mount on first DSL edit | Edit; assert single event | UI | P2 |
+| ANL-4 | `saveBtnClick`, `shareLink`, `itemsImported`, `Free Limit` fire with legacy envelope | Exercise each; assert category/label/value | mixed | P2 |
+
+## 20. Connectivity
+
+| ID | Behavior | Method | Dep | Pri |
+|----|----------|--------|-----|-----|
+| NET-1 | Offline status reflected in UI; local edits still persist | Go offline; edit; assert offline indicator + local save | UI | P2 |
+| NET-2 | Reconnect resumes cloud sync without data loss | AUTH; offline edits; reconnect; assert synced | AUTH/CLOUD | P2 |
+
+---
+
+## Coverage map (what unlocks what)
+
+| Bucket | Cases | Runnable today (signed-out, live deploy) |
+|--------|-------|-------------------------------------------|
+| `UI` (pure browser) | CSS-1..4/6, PRV-1..4/6..8, PG-*, LIB-1..8(local), TPL-*, SET-1..6/8, PST-1/5, EXP-1..5, SUB-1/6, HDR-1..3/5, KB-*, EMB-2..4, MOD-*, ANL-1/3, NET-1 | **Yes** — biggest immediate win; add as new root specs |
+| `MOBILE` | PRV-5, MOB-1..4 | Yes (Playwright device project) |
+| `AUTH` | AUTH-*, IOL-*, SET-7, PST-2, SHR-1, SUB-3/5, HDR-6 | Needs Firebase **Auth emulator** / test account |
+| `CLOUD` | FLD-*, PST-3/4, SHR-2..8, SUB-4, HDR-4, EMB-1, NET-2 | Needs **Firestore + functions emulator** |
+| `PADDLE` | SUB-2/3 | Needs Paddle **sandbox** or mocked `usePaddle` |
+
+**Recommended sequencing**
+1. **P0/P1 `UI` cases** → new specs `e2e/tests/{preview,library-actions,settings,export,multipage,modals,templates}.spec.js`. No infra; runs in the staging gate signed-out. Largest coverage gain for least cost.
+2. **`MOBILE`** → a Playwright `devices['Pixel 7']`/`iPhone 14` project; covers PRV-5 + MOB-*.
+3. **Emulator project** `*.cloud.spec.js` (auth + firestore + functions) → unlocks AUTH/CLOUD (sharing, folders, plan limits, import-on-login, save indicator).
+4. **Paddle** mock → SUB-2/3.
+
+**Out of e2e scope (keep at unit level — already covered):** transpiler logic
+(`transpilers`), `buildIssueUrl`, `exportImport` parse/merge, `planLimit`,
+`semver`, `templates`, store reducers, `parseEmbedCode`. The e2e cases above
+target the **UI + wiring**, not this logic.

--- a/e2e/EMULATOR_SETUP.md
+++ b/e2e/EMULATOR_SETUP.md
@@ -1,0 +1,215 @@
+# Emulator setup — unlocking the infra-gated E2E gap cases
+
+The `AUTH` / `CLOUD` / `PADDLE` cases in `e2e/E2E_GAP_TEST_PLAN.md` are scaffolded
+as **pending** (`test.fixme`) in [`e2e/tests/cloud.fixme.spec.js`](tests/cloud.fixme.spec.js).
+They cannot run in a plain checkout: the signed-out staging gate runs anonymously
+against a live deploy, so it never touches auth, Firestore, the cloud functions,
+or Paddle. This doc is the concrete recipe to stand that infra up locally and flip
+each `test.fixme(...)` → `test(...)`.
+
+What unlocks what (from the gap-plan coverage map):
+
+| Bucket   | Cases                                                                     | Infra needed                                       |
+| -------- | ------------------------------------------------------------------------- | -------------------------------------------------- |
+| `AUTH`   | AUTH-1..6, IOL-1, SHR-1, HDR-6, CSS-5, SUB-5                              | Firebase **Auth** emulator + a seeded test user    |
+| `CLOUD`  | IOL-2/3, FLD-1..5, SHR-2..8, PST-2/3/4, HDR-4, EMB-1, NET-2, SET-7, SUB-4 | **Auth + Firestore + Functions** emulators         |
+| `PADDLE` | SUB-2, SUB-3                                                              | mocked `window.Paddle` (no sandbox account needed) |
+
+---
+
+## 1. Why a separate Playwright project
+
+`playwright.config.js` boots the app via `pnpm -C web dev` (port 3000) with **no**
+emulator. These cloud cases need the app pointed at the Firebase emulators instead.
+Add a second project rather than mutating the existing one, so the signed-out
+staging gate is untouched.
+
+```js
+// playwright.config.js — add to `projects` (sketch)
+{
+  name: 'cloud',
+  testMatch: /cloud\.fixme\.spec\.js/,        // rename to *.cloud.spec.js once un-fixme'd
+  use: { ...devices['Desktop Chrome'] },
+},
+```
+
+And add an emulator-backed web server to `resolveWebServers()` (guarded by an env
+flag so it only runs when you intend to exercise the cloud project):
+
+```js
+// the app must boot with VITE_USE_EMULATOR=1 so firebase.ts wires the emulators (§2)
+{
+  command: 'firebase emulators:exec --only auth,firestore,functions "VITE_USE_EMULATOR=1 pnpm -C web dev"',
+  url: 'http://localhost:3000',
+  reuseExistingServer: !process.env.CI,
+  timeout: 180 * 1000,
+},
+```
+
+Emulator ports are already declared in [`firebase.json`](../firebase.json):
+`auth` (add it — see §2), `firestore` :8080, `functions` :5002, UI :4000.
+Add the auth port to `firebase.json`:
+
+```jsonc
+"emulators": {
+  "auth":      { "port": 9099 },   // ADD THIS
+  "functions": { "port": 5002 },
+  "firestore": { "port": 8080 },
+  "hosting":   { "port": 5000 },
+  "ui": { "enabled": true, "port": 4000 }
+}
+```
+
+---
+
+## 2. Wire the app to the emulators (`web/src/services/firebase.ts`)
+
+Today [`web/src/services/firebase.ts`](../web/src/services/firebase.ts) calls
+`getAuth(app)` and `initializeFirestore(app, …)` with **no** emulator connection.
+Add an opt-in block, gated on a Vite env flag so production builds never connect:
+
+```ts
+// web/src/services/firebase.ts — after `export const auth` / `export const db`
+import { connectAuthEmulator } from 'firebase/auth';
+import { connectFirestoreEmulator } from 'firebase/firestore';
+
+if (import.meta.env.VITE_USE_EMULATOR === '1') {
+  connectAuthEmulator(auth, 'http://localhost:9099', { disableWarnings: true });
+  connectFirestoreEmulator(db, 'localhost', 8080);
+}
+```
+
+The cloud-function rewrites (`/create-share`, `/sync-diagram`, `/get-shared-item`,
+defined in [`firebase.json`](../firebase.json)) are served by the **functions**
+emulator. `firebase emulators:exec` makes the hosting rewrites resolve to the local
+functions automatically; if you boot `pnpm -C web dev` directly instead, proxy
+those paths to `http://localhost:5002` in `web/vite.config.*` so the relative
+`fetch('/get-shared-item?…')` in
+[`web/src/services/cloudFunctions.ts`](../web/src/services/cloudFunctions.ts) hits
+the emulator.
+
+> NOTE: the functions emulator runs `functions/index.js`. `create_share` /
+> `get_shared_item` read/write Firestore via the admin SDK — with the Firestore
+> emulator up, the admin SDK auto-targets it when `FIRESTORE_EMULATOR_HOST` is set,
+> which `emulators:exec` sets for you.
+
+---
+
+## 3. Seed a test user (Auth emulator)
+
+The Auth emulator accepts unsigned tokens and lets you create users via its REST
+API or the admin SDK — no real Google/GitHub OAuth round-trip. Two ways:
+
+**A. Admin SDK (deterministic, recommended)** — a global-setup script mints users
+and custom tokens against the emulator:
+
+```js
+// e2e/cloud/seed.mjs  (run from Playwright globalSetup)
+import admin from 'firebase-admin';
+process.env.FIRESTORE_EMULATOR_HOST = 'localhost:8080';
+process.env.FIREBASE_AUTH_EMULATOR_HOST = 'localhost:9099';
+admin.initializeApp({ projectId: 'web-sequence-local' });
+
+export async function seedUser(uid, email) {
+  await admin
+    .auth()
+    .createUser({ uid, email, displayName: 'E2E User' })
+    .catch(() => {});
+  return admin.auth().createCustomToken(uid); // the test signs in with this
+}
+```
+
+**B. Emulator REST** — `POST http://localhost:9099/identitytoolkit.googleapis.com/v1/accounts:signUp?key=fake`
+with `{ email, password, returnSecureToken: true }`. Returns an idToken you can
+inject. Heavier than the admin SDK; prefer A.
+
+---
+
+## 4. The in-page sign-in hook the spec calls
+
+`cloud.fixme.spec.js` calls `window.__e2eSignIn({ uid, email })` (and
+`window.__e2eForceAuthError`). Expose these **dev-only** hooks so the spec can
+authenticate deterministically without driving an OAuth popup. Add to
+`web/src/services/firebase.ts` behind the same `VITE_USE_EMULATOR` flag:
+
+```ts
+import { signInWithCustomToken } from 'firebase/auth';
+if (import.meta.env.VITE_USE_EMULATOR === '1') {
+  // The test mints the token via the admin SDK (§3A) and passes it in, OR the
+  // hook fetches one from a tiny local endpoint. Keep this OUT of prod bundles.
+  (window as any).__e2eSignIn = async ({ token }: { token: string }) =>
+    signInWithCustomToken(auth, token);
+  (window as any).__e2eForceAuthError = (code: string) => {
+    (window as any).__e2eAuthErrorCode = code; // LoginModal/onLogin reads + throws this
+  };
+}
+```
+
+The spec's `signInViaEmulator()` helper is the single seam — point it at whichever
+of A/B you choose; nothing else in the spec changes.
+
+---
+
+## 5. Firestore admin probes (the "no cloud write" / "synced" assertions)
+
+Several cases assert a Firestore **side effect**, not just UI: IOL-2/3 (uploaded /
+not uploaded), SUB-4 (4th doc withheld), NET-2 (offline edit synced after
+reconnect), SET-7 (settings persisted). Read the emulator directly with the admin
+SDK in the test (or a fixture):
+
+```js
+import admin from 'firebase-admin'; // already pointed at the emulator (§3)
+const db = admin.firestore();
+const snap = await db.collection('users').doc(uid).collection('items').get();
+expect(snap.size).toBe(expectedCount);
+```
+
+The web client writes diagrams under the user's items collection and folders on the
+`users/{uid}` doc (`folders` field) — confirm the exact paths in
+`web/src/services/itemService.ts` / `folderService.ts` when you wire each probe.
+
+---
+
+## 6. Mocking Paddle (SUB-2, SUB-3) — no sandbox account needed
+
+[`web/src/hooks/usePaddle.ts`](../web/src/hooks/usePaddle.ts) has a deliberate
+seam: `ensurePaddle()` (line ~61) sees an existing `window.Paddle` and **skips the
+CDN inject**, just calling `Setup`. So a Playwright `addInitScript` that installs a
+stub BEFORE app boot fully controls checkout — the spec already does this:
+
+```js
+await page.addInitScript(() => {
+  window.__paddleCalls = [];
+  window.Paddle = {
+    Setup() {},
+    Checkout: { open: (o) => window.__paddleCalls.push(o) },
+  };
+});
+// … later, assert openCheckout was called with the right plan:
+const calls = await page.evaluate(() => window.__paddleCalls);
+expect(JSON.parse(calls[0].passthrough)).toMatchObject({
+  planType: 'plus-monthly',
+});
+```
+
+`openCheckout` (usePaddle.ts:92) resolves the product id from `firebaseConfig.ts`
+and passes `JSON.stringify({ userId, planType })` as `passthrough` — that's the
+assertable contract. No Paddle sandbox vendor/account is required for the E2E
+gate; the unit test `web/src/hooks/usePaddle.test.tsx` already covers the SDK
+plumbing, and these E2E cases only verify the **UI → openCheckout wiring**.
+
+---
+
+## 7. Flipping the scaffold on
+
+Once §1–§6 are in place, per case:
+
+1. Replace `test.fixme(` → `test(` for the cases whose infra is now live.
+2. Run only the cloud project: `npx playwright test --project=cloud`.
+3. Tighten any sketch that the real run surfaces (timing waits, exact seed shape,
+   the precise move-to-folder / manage-subscription testids marked "TBD" inline).
+
+Rename the file `cloud.fixme.spec.js` → `cloud.spec.js` when the majority are
+active, and add the `cloud` project to CI as a **separate** job from the
+signed-out staging gate (it needs the emulator services, so it can't share the
+anonymous-against-live-deploy runner).

--- a/e2e/tests/cloud.fixme.spec.js
+++ b/e2e/tests/cloud.fixme.spec.js
@@ -1,0 +1,685 @@
+// Infra-gated E2E gap cases — AUTH / CLOUD / PADDLE buckets from
+// e2e/E2E_GAP_TEST_PLAN.md, captured as a runnable-but-PENDING scaffold.
+//
+// WHY EVERY CASE IS test.fixme():
+//   These cases need infrastructure that is NOT available in this checkout:
+//     - the Firebase Emulator Suite (auth + firestore + functions), and
+//     - a Paddle sandbox / a mocked `usePaddle` openCheckout.
+//   The signed-out staging gate cannot reach them (it runs anonymously against a
+//   live deploy). Rather than delete or fake-pass them, each is written as a real
+//   body sketch wrapped in `test.fixme(title, fn)`. Playwright reports a fixme
+//   test as PENDING (skipped) — it is NEVER executed, so the body cannot fail the
+//   suite, and it cannot fake-pass either. The moment the emulator project exists
+//   (see e2e/EMULATOR_SETUP.md), flip `test.fixme` → `test` per case and the body
+//   is already written against the real selectors.
+//
+// SELECTORS ARE REAL: every data-testid referenced below was read out of the
+// live components (web/src/components/**), so the sketches are accurate, not
+// guesses. The bodies are best-effort and may need small timing/seed tweaks once
+// the emulator is wired — that is exactly what un-fixme-ing each case will surface.
+//
+// NAMING: each fixme title starts with its gap-plan ID and a one-line
+//   "needs: <emulator|paddle> — <what to do>" note, so `--list` reads as a
+//   checklist of what infra unlocks what.
+//
+// HELPERS reused from the signed-out specs (openEditor/gotoHome/typeDsl pattern):
+//   the emulator project keeps the same page-driving shape; only auth/seed change.
+
+import { test, expect } from '@playwright/test';
+import { suppressOneTimeModals } from './helpers/onetime';
+import { openEditor, gotoHome } from './helpers/hub';
+
+const selectAll = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
+
+// ── shared sketch helpers (intentionally NOT exported; these run only once the
+//    emulator project is live, so they live beside the cases that use them) ─────
+
+/** Editor CM6 content surface. */
+function editorLocator(page) {
+  return page.locator('[data-testid="dsl-editor"] .cm-content');
+}
+
+/**
+ * Sign in via the emulator. PLACEHOLDER until the emulator project exists:
+ * with the Auth emulator wired (see EMULATOR_SETUP.md §3), real flows are either
+ *   (a) seed a custom token into the page and call signInWithCustomToken, or
+ *   (b) drive the emulator's popup provider stub.
+ * Sketch (a) — the deterministic one — is shown; it needs `firebase/auth` exposed
+ * on window in dev OR an addInitScript that signs in before AppRoot boots.
+ */
+async function signInViaEmulator(
+  page,
+  { uid = 'e2e-user', email = 'e2e@test.local' } = {},
+) {
+  // needs: Auth emulator + a test custom token (EMULATOR_SETUP.md §3/§4)
+  await page.evaluate(
+    async ({ uid, email }) => {
+      // window.__e2eSignIn is the dev-only test hook described in EMULATOR_SETUP.md §4.
+      // It wraps signInWithCustomToken(auth, <minted token for uid>).
+      await window.__e2eSignIn?.({ uid, email });
+    },
+    { uid, email },
+  );
+  // ProfileMenu's trigger only mounts once onAuthStateChanged fires signed-in.
+  await expect(page.locator('[data-testid="profile-trigger"]')).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+/** Boot the editor with a clean slate + one-time modals suppressed. */
+async function gotoFresh(page) {
+  await suppressOneTimeModals(page);
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await openEditor(page);
+}
+
+/** Type a replacement DSL into the editor (select-all → Delete → type). */
+async function typeDsl(page, dsl) {
+  const editor = editorLocator(page);
+  await expect(editor).toBeVisible({ timeout: 15_000 });
+  await editor.click();
+  await page.keyboard.press(selectAll);
+  await page.keyboard.press('Delete');
+  await editor.pressSequentially(dsl);
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// §9 Authentication  (AUTH-1..6)  — Firebase Auth emulator
+// ════════════════════════════════════════════════════════════════════════════
+
+test.fixme(
+  'AUTH-1 — needs: emulator (auth) — login modal lists Google/GitHub/Facebook/Twitter',
+  async ({ page }) => {
+    await gotoFresh(page);
+    // Header "Sign in" opens LoginModal. (header-login → AppHeader.tsx:379)
+    await page.locator('[data-testid="header-login"]').click();
+    // LoginModal renders one button per provider, testid login-<id>
+    // (web/src/components/auth/LoginModal.tsx:87 → `login-${id}`).
+    for (const id of ['google', 'github', 'facebook', 'twitter']) {
+      await expect(page.locator(`[data-testid="login-${id}"]`)).toBeVisible();
+    }
+  },
+);
+
+test.fixme(
+  'AUTH-2 — needs: emulator (auth) — Google sign-in → profile menu shows name/photo/plan',
+  async ({ page }) => {
+    await gotoFresh(page);
+    await signInViaEmulator(page, { uid: 'auth2', email: 'auth2@test.local' });
+    // ProfileMenu trigger present; opening it reveals the plan row (profile-plan).
+    await page.locator('[data-testid="profile-trigger"]').click();
+    await expect(page.locator('[data-testid="profile-plan"]')).toBeVisible();
+    // Free account → "Free" / Starter copy in the plan row.
+    await expect(page.locator('[data-testid="profile-plan"]')).toContainText(
+      /free|starter/i,
+    );
+  },
+);
+
+test.fixme(
+  'AUTH-3 — needs: emulator (auth) — last-used provider re-surfaces as primary with a "Last used" chip',
+  async ({ page }) => {
+    await gotoFresh(page);
+    // Sign in with GitHub, then sign out. LoginModal persists lastProvider.
+    await page.locator('[data-testid="header-login"]').click();
+    await page.locator('[data-testid="login-github"]').click(); // emulator GitHub stub completes
+    await page.locator('[data-testid="profile-trigger"]').click();
+    await page.locator('[data-testid="profile-logout"]').click();
+    // Reopen → GitHub elevated (cobalt primary) + login-github-lastused chip
+    // (LoginModal.tsx:105 → `login-${id}-lastused`).
+    await page.locator('[data-testid="header-login"]').click();
+    await expect(
+      page.locator('[data-testid="login-github-lastused"]'),
+    ).toBeVisible();
+  },
+);
+
+test.fixme(
+  'AUTH-4 — needs: emulator (auth) — auth error surfaces in the modal alert',
+  async ({ page }) => {
+    await gotoFresh(page);
+    await page.locator('[data-testid="header-login"]').click();
+    // Force the provider to reject (emulator: configure the provider to fail, or
+    // stub signInWithPopup to throw). LoginModal renders the message in login-error
+    // (LoginModal.tsx:128).
+    await page.evaluate(() => {
+      window.__e2eForceAuthError?.('auth/popup-closed-by-user');
+    });
+    await page.locator('[data-testid="login-google"]').click();
+    await expect(page.locator('[data-testid="login-error"]')).toBeVisible();
+  },
+);
+
+test.fixme(
+  'AUTH-5 — needs: emulator (auth) — login modal auto-dismisses once auth resolves (P5 regression)',
+  async ({ page }) => {
+    await gotoFresh(page);
+    await page.locator('[data-testid="header-login"]').click();
+    await expect(page.locator('[data-testid="login-google"]')).toBeVisible();
+    await signInViaEmulator(page); // resolves onAuthStateChanged
+    // Modal closes automatically — the provider buttons unmount.
+    await expect(page.locator('[data-testid="login-google"]')).toBeHidden();
+  },
+);
+
+test.fixme(
+  'AUTH-6 — needs: emulator (auth) — sign-out clears session, hides profile menu, restores "Sign in"',
+  async ({ page }) => {
+    await gotoFresh(page);
+    await signInViaEmulator(page);
+    await page.locator('[data-testid="profile-trigger"]').click();
+    await page.locator('[data-testid="profile-logout"]').click();
+    // Signed-out chrome: profile gone, header-login back.
+    await expect(page.locator('[data-testid="profile-trigger"]')).toBeHidden();
+    await expect(page.locator('[data-testid="header-login"]')).toBeVisible();
+  },
+);
+
+// ════════════════════════════════════════════════════════════════════════════
+// §10 Import-on-login  (IOL-1..3)  — Auth (+ Firestore for the upload assertion)
+// ════════════════════════════════════════════════════════════════════════════
+
+test.fixme(
+  'IOL-1 — needs: emulator (auth) — first sign-in with local diagrams offers AskToImportModal',
+  async ({ page }) => {
+    await gotoFresh(page);
+    // Seed a local item first (save signed-out → localItems index).
+    await typeDsl(page, 'A\nB\nA->B: local');
+    await page.locator('[data-testid="header-menu"]').click();
+    await page.locator('[data-testid="header-save"]').click();
+    await page
+      .locator('[data-testid="confirm-cancel"]')
+      .click()
+      .catch(() => {}); // first-save notice
+    // Sign in → useImportOnLogin detects locals → AskToImportModal
+    // (import-confirm / import-dismiss → AskToImportModal.tsx:28/41).
+    await signInViaEmulator(page);
+    await expect(page.locator('[data-testid="import-confirm"]')).toBeVisible();
+  },
+);
+
+test.fixme(
+  'IOL-2 — needs: emulator (auth+firestore) — accepting import uploads locals to the cloud account',
+  async ({ page }) => {
+    await gotoFresh(page);
+    await typeDsl(page, 'A\nB\nA->B: local');
+    await page.locator('[data-testid="header-menu"]').click();
+    await page.locator('[data-testid="header-save"]').click();
+    await page
+      .locator('[data-testid="confirm-cancel"]')
+      .click()
+      .catch(() => {});
+    await signInViaEmulator(page);
+    await page.locator('[data-testid="import-confirm"]').click();
+    // After a fresh reload signed-in, the item is read from the cloud account.
+    await gotoHome(page);
+    await expect(page.locator('[data-testid^="home-card-"]')).toHaveCount(1);
+    // STRONGER assertion (needs Firestore admin probe): query the emulator's
+    // users/{uid}/items and assert the doc exists. See EMULATOR_SETUP.md §5.
+  },
+);
+
+test.fixme(
+  'IOL-3 — needs: emulator (auth+firestore) — declining keeps locals untouched, no cloud write',
+  async ({ page }) => {
+    await gotoFresh(page);
+    await typeDsl(page, 'A\nB\nA->B: local');
+    await page.locator('[data-testid="header-menu"]').click();
+    await page.locator('[data-testid="header-save"]').click();
+    await page
+      .locator('[data-testid="confirm-cancel"]')
+      .click()
+      .catch(() => {});
+    await signInViaEmulator(page);
+    await page.locator('[data-testid="import-dismiss"]').click();
+    // Firestore admin probe: assert users/{uid}/items is empty (no upload).
+    // EMULATOR_SETUP.md §5 shows the admin-SDK read against the emulator.
+  },
+);
+
+// ════════════════════════════════════════════════════════════════════════════
+// §5 Folders  (FLD-1..5)  — Auth + Firestore (folders live on users/{uid}.folders)
+// ════════════════════════════════════════════════════════════════════════════
+// Folders are cloud-backed (useFolders.ts / folderService.ts write users/{uid}),
+// so they need the Firestore emulator + a signed-in session.
+
+test.fixme(
+  'FLD-1 — needs: emulator (auth+firestore) — create folder "Work" appears with count 0',
+  async ({ page }) => {
+    await signInViaEmulator(page);
+    await gotoHome(page);
+    // folder-new → folder-new-input (testids confirmed in the folder UI).
+    await page.locator('[data-testid="folder-new"]').click();
+    await page.locator('[data-testid="folder-new-input"]').fill('Work');
+    await page.keyboard.press('Enter');
+    await expect(page.getByText('Work', { exact: true })).toBeVisible();
+    // Count chip reads 0 on a fresh folder.
+  },
+);
+
+test.fixme(
+  'FLD-2 — needs: emulator (auth+firestore) — move a diagram into a folder; counts update; Unfiled decrements',
+  async ({ page }) => {
+    await signInViaEmulator(page);
+    await gotoHome(page);
+    // Seed item + folder, then move via the card kebab → "Move to". Assert the
+    // Work count increments to 1 and folder-unfiled decrements.
+    // (Exact move-menu testid TBD when the emulator project lands — folder-${id}.)
+  },
+);
+
+test.fixme(
+  'FLD-3 — needs: emulator (auth+firestore) — rename folder commits the new label',
+  async ({ page }) => {
+    await signInViaEmulator(page);
+    await gotoHome(page);
+    // Open the folder row menu → Rename → type → Enter; assert new label visible.
+  },
+);
+
+test.fixme(
+  'FLD-4 — needs: emulator (auth+firestore) — delete folder returns its items to Unfiled',
+  async ({ page }) => {
+    await signInViaEmulator(page);
+    await gotoHome(page);
+    // Delete a folder holding 1 item; assert folder-unfiled count increments and
+    // the item still appears under Unfiled.
+  },
+);
+
+test.fixme(
+  'FLD-5 — needs: emulator (auth+firestore) — "All" vs "Unfiled" filters the grid',
+  async ({ page }) => {
+    await signInViaEmulator(page);
+    await gotoHome(page);
+    // folder-all shows every card; folder-unfiled shows only unfoldered cards.
+    await page.locator('[data-testid="folder-all"]').click();
+    const allCount = await page.locator('[data-testid^="home-card-"]').count();
+    await page.locator('[data-testid="folder-unfiled"]').click();
+    const unfiledCount = await page
+      .locator('[data-testid^="home-card-"]')
+      .count();
+    expect(unfiledCount).toBeLessThanOrEqual(allCount);
+  },
+);
+
+// ════════════════════════════════════════════════════════════════════════════
+// §11 Sharing  (SHR-1..8)  — SHR-1 is AUTH-only; SHR-2..8 need Firestore+functions
+// ════════════════════════════════════════════════════════════════════════════
+// create-share / get-shared-item are cloud functions (firebase.json rewrites);
+// they read the cloud item doc and need a fresh ID token → emulator functions.
+
+test.fixme(
+  'SHR-1 — needs: emulator (auth) — Share while signed-out opens the sign-in modal first',
+  async ({ page }) => {
+    await gotoFresh(page);
+    // ShareButton is signed-out-gated: clicking it should route to LoginModal.
+    await page.locator('[data-testid="share-button"]').click();
+    await expect(page.locator('[data-testid="login-google"]')).toBeVisible();
+  },
+);
+
+test.fixme(
+  'SHR-2 — needs: emulator (auth+firestore+functions) — create share link → popover shows ?id=&share-token= URL',
+  async ({ page }) => {
+    await signInViaEmulator(page);
+    await gotoFresh(page);
+    await typeDsl(page, 'A\nB\nA->B: share me');
+    // Save so the item exists in the cloud (create-share reads the cloud doc).
+    await page.locator('[data-testid="header-menu"]').click();
+    await page.locator('[data-testid="header-save"]').click();
+    // Open share popover → Create link (share-create → SharePopover.tsx:82),
+    // then assert the URL field carries both params (share-url → :36).
+    await page.locator('[data-testid="share-button"]').click();
+    await page.locator('[data-testid="share-create"]').click();
+    const url = page.locator('[data-testid="share-url"]');
+    await expect(url).toBeVisible();
+    await expect(url).toHaveValue(/[?&]id=.+&share-token=.+/);
+  },
+);
+
+test.fixme(
+  'SHR-3 — needs: emulator (auth+firestore+functions) — Copy copies the URL and shows "Copied ✓"',
+  async ({ page, context }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await signInViaEmulator(page);
+    await gotoFresh(page);
+    await typeDsl(page, 'A\nB\nA->B: copy');
+    await page.locator('[data-testid="header-menu"]').click();
+    await page.locator('[data-testid="header-save"]').click();
+    await page.locator('[data-testid="share-button"]').click();
+    await page.locator('[data-testid="share-create"]').click();
+    await page.locator('[data-testid="share-copy"]').click(); // SharePopover.tsx:45
+    const clip = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clip).toMatch(/[?&]id=.+&share-token=.+/);
+  },
+);
+
+test.fixme(
+  'SHR-4 — needs: emulator (auth+firestore+functions) — Stop-sharing revokes the token',
+  async ({ page }) => {
+    await signInViaEmulator(page);
+    await gotoFresh(page);
+    await typeDsl(page, 'A\nB\nA->B: revoke');
+    await page.locator('[data-testid="header-menu"]').click();
+    await page.locator('[data-testid="header-save"]').click();
+    await page.locator('[data-testid="share-button"]').click();
+    await page.locator('[data-testid="share-create"]').click();
+    const url = await page.locator('[data-testid="share-url"]').inputValue();
+    await page.locator('[data-testid="share-stop"]').click(); // SharePopover.tsx:56
+    // Re-visiting the now-revoked URL should NOT render the diagram (token gone).
+    await page.goto(url);
+    await expect(
+      page.locator('[data-testid="share-error-text"]'),
+    ).toBeVisible();
+  },
+);
+
+test.fixme(
+  'SHR-5 — needs: emulator (firestore+functions) — opening a share URL renders read-only + "Open in ZenUML"',
+  async ({ page }) => {
+    // Pre-seed a shared item in Firestore (admin SDK, EMULATOR_SETUP.md §5) and
+    // build ${origin}/?id=<id>&share-token=<tok>. useBootItem calls getSharedItem
+    // (cloudFunctions.ts:51) → item with isReadOnly:true.
+    const id = 'seeded-shared-id';
+    const token = 'seeded-token';
+    await page.goto(`/?id=${id}&share-token=${token}`);
+    await expect(editorLocator(page)).toBeVisible();
+    // Read-only chrome: header-savestate is in the "readonly" state (AppHeader.tsx:488).
+    await expect(
+      page.locator('[data-testid="header-savestate"]'),
+    ).toHaveAttribute('data-state', 'readonly');
+  },
+);
+
+test.fixme(
+  'SHR-6 — needs: emulator (firestore+functions) — Fork a shared item → owned editable copy (clears readonly/shareToken)',
+  async ({ page }) => {
+    await signInViaEmulator(page);
+    const id = 'seeded-shared-id';
+    const token = 'seeded-token';
+    await page.goto(`/?id=${id}&share-token=${token}`);
+    // Fork lives in the header file-menu (filemenu-duplicate → AppHeader.tsx:293).
+    await page.locator('[data-testid="header-menu"]').click();
+    await page.locator('[data-testid="filemenu-duplicate"]').click();
+    // After fork: savestate leaves readonly (becomes dirty/saved, owned copy).
+    await expect(
+      page.locator('[data-testid="header-savestate"]'),
+    ).not.toHaveAttribute('data-state', 'readonly');
+  },
+);
+
+test.fixme(
+  'SHR-7 — needs: emulator (firestore+functions) — bad share link → ShareErrorNotice with "Start fresh"',
+  async ({ page }) => {
+    // getSharedItem rejects for an unknown token → useBootItem yields share-error.
+    await page.goto('/?id=does-not-exist&share-token=bad');
+    await expect(page.locator('[data-testid="share-error"]')).toBeVisible();
+    await expect(
+      page.locator('[data-testid="share-error-fresh"]'),
+    ).toBeVisible(); // "Start fresh"
+  },
+);
+
+test.fixme(
+  'SHR-8 — needs: emulator (firestore+functions) — Share button disabled for read-only items',
+  async ({ page }) => {
+    await signInViaEmulator(page);
+    await page.goto('/?id=seeded-shared-id&share-token=seeded-token');
+    await expect(editorLocator(page)).toBeVisible();
+    // ShareButton renders disabled for read-only items (ShareButton.tsx:60 branch).
+    await expect(page.locator('[data-testid="share-button"]')).toBeDisabled();
+  },
+);
+
+// ════════════════════════════════════════════════════════════════════════════
+// §13 Subscription / pricing  (SUB-2/3/4/5)
+// ════════════════════════════════════════════════════════════════════════════
+
+test.fixme(
+  'SUB-2 — needs: paddle (mock usePaddle.openCheckout) — Upgrade (signed-in) opens Paddle checkout for the chosen plan',
+  async ({ page }) => {
+    // Install a window.Paddle stub BEFORE app boot so usePaddle.ensurePaddle()
+    // picks it up (usePaddle.ts:61 — "Paddle already present" path skips the CDN).
+    // EMULATOR_SETUP.md §6 shows the addInitScript stub that records Checkout.open.
+    await page.addInitScript(() => {
+      window.__paddleCalls = [];
+      window.Paddle = {
+        Setup() {},
+        Checkout: { open: (opts) => window.__paddleCalls.push(opts) },
+      };
+    });
+    await signInViaEmulator(page);
+    await gotoFresh(page);
+    await page.locator('[data-testid="header-pricing"]').click(); // open PricingModal
+    await page.locator('[data-testid="pricing-period-monthly"]').click();
+    // Click an Upgrade CTA on the Plus tier (profile-upgrade / pricing tier button).
+    await page.locator('[data-testid="profile-upgrade"]').first().click();
+    // usePaddle passes JSON.stringify({ userId, planType }) as passthrough.
+    const calls = await page.evaluate(() => window.__paddleCalls);
+    expect(calls.length).toBe(1);
+    expect(JSON.parse(calls[0].passthrough)).toMatchObject({
+      planType: 'plus-monthly',
+    });
+  },
+);
+
+test.fixme(
+  'SUB-3 — needs: emulator (auth) + paddle (mock) — anonymous Upgrade → sign-in → resumes checkout for captured plan',
+  async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__paddleCalls = [];
+      window.Paddle = {
+        Setup() {},
+        Checkout: { open: (o) => window.__paddleCalls.push(o) },
+      };
+    });
+    await gotoFresh(page);
+    await page.locator('[data-testid="header-pricing"]').click();
+    // Anonymous Upgrade should stash the plan and open LoginModal first.
+    await page
+      .locator('[data-testid="profile-upgrade"]')
+      .first()
+      .click()
+      .catch(() => {});
+    await expect(page.locator('[data-testid="login-google"]')).toBeVisible();
+    await signInViaEmulator(page);
+    // After auth resolves, checkout resumes for the captured plan (legacy product 5751479).
+    const calls = await page.evaluate(() => window.__paddleCalls);
+    expect(calls.length).toBe(1);
+  },
+);
+
+test.fixme(
+  'SUB-4 — needs: emulator (auth+firestore) — free user over 3 diagrams → limit notice + "Free Limit" event; local kept, cloud write withheld',
+  async ({ page }) => {
+    await signInViaEmulator(page, { uid: 'free-cap-user' });
+    await gotoFresh(page);
+    // Seed 3 saved diagrams (the free cap), then attempt a 4th save.
+    // LimitReachedNotice mounts (limit-notice → LimitReachedNotice.tsx:25) with a
+    // limit-upgrade CTA (:41). Firestore admin probe: assert the 4th doc was NOT
+    // written (cloud write withheld) while the local copy is kept.
+    // ... seed loop omitted in the sketch; see EMULATOR_SETUP.md §5 for the probe.
+    await expect(page.locator('[data-testid="limit-notice"]')).toBeVisible();
+    await expect(page.locator('[data-testid="limit-upgrade"]')).toBeVisible();
+  },
+);
+
+test.fixme(
+  'SUB-5 — needs: emulator (auth) — "Manage subscription" link present for paid users (Paddle cancel URL)',
+  async ({ page }) => {
+    // Seed a paid (plus) user doc in Firestore so resolved plan === plus, then open
+    // the profile menu and assert the manage-subscription link is present.
+    await signInViaEmulator(page, { uid: 'plus-user' });
+    await page.locator('[data-testid="profile-trigger"]').click();
+    await expect(page.locator('[data-testid="profile-plan"]')).toContainText(
+      /plus/i,
+    );
+    // Manage-subscription link (Paddle cancel URL) — exact testid TBD when wired.
+  },
+);
+
+// ════════════════════════════════════════════════════════════════════════════
+// §8 Persistence / autosave  (PST-2/3/4)
+// ════════════════════════════════════════════════════════════════════════════
+
+test.fixme(
+  'PST-2 — needs: emulator (auth) — save indicator transitions Unsaved → Saving… → Saved (signed-in)',
+  async ({ page }) => {
+    await signInViaEmulator(page);
+    await gotoFresh(page);
+    await typeDsl(page, 'A\nB\nA->B: dirty');
+    // header-savestate cycles data-state dirty → saving → saved (AppHeader.tsx:449/457/471).
+    await expect(
+      page.locator('[data-testid="header-savestate"]'),
+    ).toHaveAttribute('data-state', 'dirty');
+    await page.locator('[data-testid="header-menu"]').click();
+    await page.locator('[data-testid="header-save"]').click();
+    await expect(
+      page.locator('[data-testid="header-savestate"]'),
+    ).toHaveAttribute('data-state', 'saved');
+  },
+);
+
+test.fixme(
+  'PST-3 — needs: emulator (firestore+functions) — read-only (shared) item: Save disabled, Fork offered',
+  async ({ page }) => {
+    await page.goto('/?id=seeded-shared-id&share-token=seeded-token');
+    await expect(editorLocator(page)).toBeVisible();
+    // Read-only: savestate is "readonly", Save is unavailable, Fork (filemenu-duplicate) offered.
+    await expect(
+      page.locator('[data-testid="header-savestate"]'),
+    ).toHaveAttribute('data-state', 'readonly');
+    await page.locator('[data-testid="header-menu"]').click();
+    await expect(page.locator('[data-testid="header-save"]')).toBeDisabled();
+    await expect(
+      page.locator('[data-testid="filemenu-duplicate"]'),
+    ).toBeVisible();
+  },
+);
+
+test.fixme(
+  'PST-4 — needs: emulator (firestore+functions) — read-only item is NOT written to the last-code slot',
+  async ({ page }) => {
+    await page.goto('/?id=seeded-shared-id&share-token=seeded-token');
+    await expect(editorLocator(page)).toBeVisible();
+    const sharedFirstLine = (await editorLocator(page).innerText()).split(
+      '\n',
+    )[0];
+    // Reload bare '/' — editor-as-landing resumes last-code; the shared item must
+    // NOT be it (read-only items skip the last-code write).
+    await page.goto('/');
+    await expect(editorLocator(page)).toBeVisible();
+    await expect(editorLocator(page)).not.toContainText(sharedFirstLine);
+  },
+);
+
+// ════════════════════════════════════════════════════════════════════════════
+// §14 Header / title / actions  (HDR-4/6)
+// ════════════════════════════════════════════════════════════════════════════
+
+test.fixme(
+  'HDR-4 — needs: emulator (firestore+functions) — Fork duplicates current item into an owned copy',
+  async ({ page }) => {
+    await signInViaEmulator(page);
+    await page.goto('/?id=seeded-shared-id&share-token=seeded-token');
+    await expect(editorLocator(page)).toBeVisible();
+    await page.locator('[data-testid="header-menu"]').click();
+    await page.locator('[data-testid="filemenu-duplicate"]').click();
+    // New owned, editable copy: savestate no longer readonly.
+    await expect(
+      page.locator('[data-testid="header-savestate"]'),
+    ).not.toHaveAttribute('data-state', 'readonly');
+  },
+);
+
+test.fixme(
+  'HDR-6 — needs: emulator (auth) — signed-out header shows "Sign in"; signed-in shows profile menu',
+  async ({ page }) => {
+    await gotoFresh(page);
+    await expect(page.locator('[data-testid="header-login"]')).toBeVisible();
+    await expect(page.locator('[data-testid="profile-trigger"]')).toBeHidden();
+    await signInViaEmulator(page);
+    await expect(page.locator('[data-testid="profile-trigger"]')).toBeVisible();
+    await expect(page.locator('[data-testid="header-login"]')).toBeHidden();
+  },
+);
+
+// ════════════════════════════════════════════════════════════════════════════
+// §16 Embed (by-reference)  (EMB-1)  — Firestore + functions
+// ════════════════════════════════════════════════════════════════════════════
+
+test.fixme(
+  'EMB-1 — needs: emulator (firestore+functions) — embed by-reference ?embed&id=&share-token= renders the shared diagram',
+  async ({ page }) => {
+    // Seed a shared item (admin SDK), then visit the embed-by-reference URL.
+    // AppRoot's embed path calls getSharedItem and renders the embed-root surface.
+    const id = 'seeded-shared-id';
+    const token = 'seeded-token';
+    await page.goto(`/?embed&id=${id}&share-token=${token}`);
+    await expect(page.locator('[data-testid="embed-root"]')).toBeVisible();
+    await expect(page.locator('[data-testid="embed-open-link"]')).toBeVisible();
+  },
+);
+
+// ════════════════════════════════════════════════════════════════════════════
+// §20 Connectivity  (NET-2)  — Auth + Firestore (offline → reconnect sync)
+// ════════════════════════════════════════════════════════════════════════════
+
+test.fixme(
+  'NET-2 — needs: emulator (auth+firestore) — reconnect resumes cloud sync without data loss',
+  async ({ page, context }) => {
+    await signInViaEmulator(page);
+    await gotoFresh(page);
+    await typeDsl(page, 'A\nB\nA->B: offline edit');
+    // Go offline, edit + save locally, then reconnect; assert the edit syncs to the
+    // cloud (Firestore admin probe confirms the doc reflects the offline edit).
+    await context.setOffline(true);
+    await page.locator('[data-testid="header-menu"]').click();
+    await page.locator('[data-testid="header-save"]').click();
+    await context.setOffline(false);
+    // After reconnect, Firestore persistence flushes the queued write. Probe the
+    // emulator doc (EMULATOR_SETUP.md §5) to assert no data loss.
+  },
+);
+
+// ════════════════════════════════════════════════════════════════════════════
+// §7 Settings  (SET-7)  — Auth + Firestore (settings persist to cloud)
+// ════════════════════════════════════════════════════════════════════════════
+
+test.fixme(
+  'SET-7 — needs: emulator (auth+firestore) — signed-in settings persist to cloud and survive a fresh session',
+  async ({ page }) => {
+    await signInViaEmulator(page, { uid: 'settings-user' });
+    await gotoFresh(page);
+    // Open settings, change a value (e.g. theme via theme-select), close.
+    await page.locator('[data-testid="header-settings"]').click();
+    await page
+      .locator('[data-testid="theme-select"]')
+      .selectOption({ index: 1 });
+    // Sign out, clear localStorage, sign back in (fresh session — no local cache):
+    // the cloud-synced setting should be restored from Firestore.
+    await page.evaluate(() => localStorage.clear());
+    await signInViaEmulator(page, { uid: 'settings-user' });
+    await page.locator('[data-testid="header-settings"]').click();
+    // Assert the previously-chosen theme is still selected (read from cloud).
+  },
+);
+
+// ════════════════════════════════════════════════════════════════════════════
+// §1 CSS gate  (CSS-5)  — Auth (non-plain CSS mode gated behind Plus)
+// ════════════════════════════════════════════════════════════════════════════
+
+test.fixme(
+  'CSS-5 — needs: emulator (auth) — non-plain CSS mode gated behind Plus for free users (→ pricing)',
+  async ({ page }) => {
+    // Free signed-in user. Expand the CSS pane, switch the mode select to SCSS.
+    await signInViaEmulator(page, { uid: 'free-css-user' });
+    await gotoFresh(page);
+    await page.locator('[data-testid="css-panel-strip"]').click(); // expand CSS pane
+    await page.locator('[data-testid="css-mode-select"]').selectOption('scss');
+    // Gate fires for free users → pricing / upgrade prompt surfaces.
+    await expect(page.locator('[data-testid="pricing-modal"]')).toBeVisible();
+  },
+);

--- a/e2e/tests/connectivity.spec.js
+++ b/e2e/tests/connectivity.spec.js
@@ -1,0 +1,217 @@
+// Connectivity — NET-1: going offline is reflected in the page runtime, and a
+// local edit made while offline SURVIVES (the editor retains the text and the
+// last-code 'code' slot is written, so a reload restores it).
+//
+// "Assert an offline indicator if one exists": this app renders NO visible
+// offline indicator. Grepping every consumer of the online state
+// (web/src/hooks/useOnlineStatus.ts → authStore.online) shows the flag is
+// consumed ONLY by itemService's sync decision (web/src/services/itemService.ts)
+// — it is never rendered to a banner/badge/aria-live, and there is no
+// data-testid="*offline*"/"*online*" anywhere in web/src. So the OBSERVABLE the
+// hook wires up is navigator.onLine itself: useOnlineStatus listens for the
+// window 'offline' event and mirrors navigator.onLine into the store. We assert
+// against that runtime signal (the proxy the product actually keys on) plus the
+// real user-visible contract — the edit survives offline.
+//
+// context.setOffline(true) flips navigator.onLine to false AND dispatches the
+// window 'offline' event that useOnlineStatus handles, exactly the path the app
+// reacts to in production.
+//
+// Editor-as-landing (2026-06-13): bare '/' boots the EDITOR directly; we land on
+// the CM6 surface via the inlined gotoFresh (clean localStorage slate → boot
+// seeds a fresh sample, openEditor lands on '/').
+
+import { test, expect } from '@playwright/test';
+import { suppressOneTimeModals } from './helpers/onetime';
+import { openEditor } from './helpers/hub';
+
+const selectAll = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
+
+// Deployed sites (staging/prod via PW_BASE_URL) load third-party analytics/CDN
+// scripts that throw their own uncaught errors we don't own; treat those as noise
+// so genuine app errors still fail the test (copied from smoke.spec.js).
+const THIRD_PARTY_ERROR_SOURCES = [
+  'userscript.js',
+  'gtm.js',
+  'googletagmanager',
+  'google-analytics',
+  'analytics.js',
+  'clarity.js',
+  'clarity.ms',
+  'paddle.js',
+  'cdn.paddle.com',
+  'zaraz',
+  'cloudflareinsights',
+];
+
+function isThirdPartyError(err) {
+  const haystack = `${err?.message || ''}\n${err?.stack || ''}`;
+  return THIRD_PARTY_ERROR_SOURCES.some((src) => haystack.includes(src));
+}
+
+/** The CM6 editor content surface. */
+function editorLocator(page) {
+  return page.locator('[data-testid="dsl-editor"] .cm-content');
+}
+
+/**
+ * Navigate to the EDITOR with a clean localStorage slate (mirrors
+ * persistence.spec.js gotoFresh). Land on the origin first to clear storage, then
+ * click through openEditor — avoids addInitScript-based clearing that would re-run
+ * on reload and wipe the 'code' slot the reload is meant to read back.
+ */
+async function gotoFresh(page) {
+  await suppressOneTimeModals(page); // M04: keep onboarding/pledge from trapping focus
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await openEditor(page);
+}
+
+/** Type a replacement DSL into the CM6 editor (select-all → Delete → type). */
+async function typeDsl(page, dsl, { timeout = 15_000 } = {}) {
+  const editor = editorLocator(page);
+  await expect(editor).toBeVisible({ timeout });
+  await editor.click();
+  await page.keyboard.press(selectAll);
+  await page.keyboard.press('Delete');
+  await editor.pressSequentially(dsl);
+}
+
+/**
+ * Flush the last-code 'code' slot. AppRoot writes localStorage['code'] on
+ * `visibilitychange` (document.hidden → true) and on `beforeunload`; dispatch
+ * visibilitychange explicitly, then poll until the slot carries `token` — proving
+ * the slot a bare-'/' reload reads back is populated (mirrors persistence.spec.js).
+ */
+async function flushCodeSlot(page, token) {
+  await page.evaluate(() => {
+    Object.defineProperty(document, 'hidden', {
+      value: true,
+      configurable: true,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+  await page.waitForFunction(
+    (t) => {
+      const raw = localStorage.getItem('code');
+      if (!raw) return false;
+      try {
+        return JSON.parse(raw)?.js?.includes(t);
+      } catch {
+        return false;
+      }
+    },
+    token,
+    { timeout: 5_000 },
+  );
+}
+
+test.beforeEach(async ({ page }) => {
+  page.on('pageerror', (err) => {
+    if (isThirdPartyError(err)) return;
+    throw err;
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// NET-1 (core, runs everywhere): going offline is reflected in the page runtime,
+// and a local edit made WHILE OFFLINE survives — editor keeps the text and the
+// last-code 'code' slot is written.
+//
+// page.evaluate(navigator.onLine) and the localStorage read are plain runtime
+// reads that work against any base URL, so this test is NOT skipped on the staging
+// gate. (Only the back-online RELOAD round-trip below needs the local clean-slate
+// guarantee and is guarded.)
+// ──────────────────────────────────────────────────────────────────────────────
+test('NET-1: offline is reflected in the page runtime and a local edit made offline survives', async ({
+  page,
+  context,
+}) => {
+  await gotoFresh(page);
+
+  // Baseline: the page reports itself online before we cut the connection.
+  expect(await page.evaluate(() => navigator.onLine)).toBe(true);
+
+  // Cut the connection. setOffline flips navigator.onLine AND fires the window
+  // 'offline' event that useOnlineStatus handles (→ authStore.setOnline(false)).
+  await context.setOffline(true);
+
+  // The offline status is reflected in the page runtime — this is the signal the
+  // product keys on (useOnlineStatus mirrors navigator.onLine into authStore.online;
+  // there is no rendered offline indicator to assert against). Poll because the
+  // 'offline' event propagates to the page on a microtask after setOffline resolves.
+  await expect
+    .poll(() => page.evaluate(() => navigator.onLine), { timeout: 5_000 })
+    .toBe(false);
+
+  // Edit the DSL while OFFLINE — distinctive token proves restore, not the starter.
+  const TOKEN = 'OfflineEditProbe';
+  const DSL = `${TOKEN}\nPeer\nPeer->${TOKEN}: madeWhileOffline`;
+  await typeDsl(page, DSL);
+
+  // The edit is retained in the editor even though we are offline (local-first:
+  // the editor never depends on the network to accept input).
+  await expect(editorLocator(page)).toContainText(TOKEN);
+
+  // And it survives to the persistence layer: the last-code 'code' slot is written
+  // on visibilitychange while still offline (offline does NOT block local writes —
+  // itemService.ts comment CQ-5: Firestore's cache queues, the local slot is always
+  // written). flushCodeSlot asserts (via waitForFunction) the slot carries the token.
+  await flushCodeSlot(page, TOKEN);
+
+  // Restore connectivity for a clean teardown; the page reports online again.
+  await context.setOffline(false);
+  await expect
+    .poll(() => page.evaluate(() => navigator.onLine), { timeout: 5_000 })
+    .toBe(true);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// NET-1 (round-trip, local-only): an edit made while OFFLINE persists across a
+// reload made AFTER coming back online — proving the offline write reached the
+// 'code' slot the bare-'/' boot reads back.
+//
+// Guarded with PW_BASE_URL skip: this relies on the clean localStorage slate from
+// gotoFresh and the deterministic 'code'-slot boot branch (preserveLastCode). On a
+// remote staging/prod target that slate isn't guaranteed and the reload-reads-slot
+// timing competes with third-party scripts, so self-skip on the staging gate (the
+// core test above already proves offline is reflected + the edit survives).
+// ──────────────────────────────────────────────────────────────────────────────
+test('NET-1: an offline edit survives a reload after coming back online', async ({
+  page,
+  context,
+}) => {
+  test.skip(
+    !!process.env.PW_BASE_URL,
+    'reload-reads-code-slot round-trip needs the local clean-slate guarantee',
+  );
+
+  await gotoFresh(page);
+
+  // Go offline, then edit.
+  await context.setOffline(true);
+  await expect
+    .poll(() => page.evaluate(() => navigator.onLine), { timeout: 5_000 })
+    .toBe(false);
+
+  const TOKEN = 'OfflineSurvivesReload';
+  const DSL = `${TOKEN}\nMate\nMate->${TOKEN}: persistAcrossReload`;
+  await typeDsl(page, DSL);
+  await expect(editorLocator(page)).toContainText(TOKEN);
+
+  // Flush the last-code slot WHILE STILL OFFLINE — the write must not depend on
+  // the network being up.
+  await flushCodeSlot(page, TOKEN);
+
+  // Come back online, then reload bare '/': boot takes the preserveLastCode branch
+  // and reads localStorage['code'], restoring our offline-made edit.
+  await context.setOffline(false);
+  await expect
+    .poll(() => page.evaluate(() => navigator.onLine), { timeout: 5_000 })
+    .toBe(true);
+
+  await page.reload();
+
+  await expect(editorLocator(page)).toBeVisible({ timeout: 15_000 });
+  await expect(editorLocator(page)).toContainText(TOKEN, { timeout: 15_000 });
+});

--- a/e2e/tests/css-editor.spec.js
+++ b/e2e/tests/css-editor.spec.js
@@ -1,0 +1,345 @@
+// CSS editor (CSS-1..CSS-6 from e2e/E2E_GAP_TEST_PLAN.md §"CSS editor").
+//
+// Signed-out / local flows only. The custom-CSS pre-processor pipeline (SCSS/Less/
+// Stylus/ACSS) is Plus-gated for SIGNED-IN users; for a SIGNED-OUT user every
+// non-plain CSS *user edit* (handleSetCssMode / handleSetCss) routes through
+// AppRoot.cssGated() which opens the sign-in modal and WITHHOLDS the change
+// (verified in web/src/app/AppRoot.tsx:604-632, and exercised by modals-gap.spec.js
+// MOD-7). So we cannot reach the compiled-CSS render path by *typing* — instead we
+// seed an item that ALREADY carries `cssMode:'scss'|'less'|'acss'` via the library
+// JSON-import path (AppRoot.handleImport → saveItems) and OPEN it (handleOpenItem →
+// loadItem). loadItem/import never call cssGated(), and the async transpile effect
+// (AppRoot.tsx:354-361 computeCss → transpiledCss → previewCss) runs purely on
+// item.cssMode/item.css regardless of auth. The preview iframe applies that CSS as
+// the textContent of `#zenumlstyle` (web/src/preview/previewHtml.ts:55 +
+// previewBootstrap.runtime.js:159-161), which is the OBSERVABLE outcome we assert.
+//
+// SURFACE NOTES (verified against web/src/** on 2026-06-18):
+//   - CSS panel (CSS-1): empty CSS → collapsed strip `css-panel-strip`; clicking it
+//     opens `css-panel-expanded` whose footer carries `css-panel-collapse`
+//     (web/src/components/editor/CssPanel.tsx). Opening the panel is NOT gated.
+//   - CSS mode select (CSS-2): a Radix Select `css-mode-select` rendering CSS_MODES
+//     (AppRoot.tsx:71-78) = CSS/SCSS/Sass/Less/Stylus/Atomic CSS. OPENING the
+//     dropdown is not gated (only *picking* a non-css option is), so the six
+//     options are assertable for a signed-out user.
+//   - ACSS settings entry (CSS-4): when item.cssMode === 'acss' the headerControls
+//     reveal an `acss-settings-open` button (AppRoot.tsx:1281-1290) that opens the
+//     AtomicCssSettingsModal (`acss-modal`, web/src/components/modals/AtomicCssSettingsModal.tsx).
+//   - Prettier-format (CSS-6): Mod-Shift-f is a CSS-only CodeMirror binding
+//     (web/src/editor/CodeEditor.tsx:196-215) that runs formatCss(prettier) and
+//     dispatches the reformatted text into the CM doc. The dispatched doc change
+//     fires @uiw's updateListener → onChange → handleSetCss, which for a SIGNED-OUT
+//     user is gated (cssGated withholds the store write; @uiw is controlled on the
+//     parent `value` and reverts the buffer). So the format result is NOT observable
+//     for a signed-out user → test.fixme.
+//   - CSS-5 (Plus-gate routes a free SIGNED-IN user to pricing): needs emulator auth
+//     → test.fixme (mirrors cloud.fixme.spec.js CSS-5).
+//
+// GUARDS: CSS-3 / CSS-4 drive a hidden <input type=file> via setInputFiles and read
+// the preview iframe — meaningful only against the local app — so they self-skip on
+// the remote staging gate (PW_BASE_URL set), the convention export/production-build
+// specs use.
+
+import { test, expect } from '@playwright/test';
+import { suppressOneTimeModals } from './helpers/onetime';
+import { openEditor, gotoHome } from './helpers/hub';
+
+// Deployed sites load third-party analytics/CDN scripts that throw uncaught errors
+// we don't own; treat those as noise (copied verbatim from smoke/library specs).
+const THIRD_PARTY_ERROR_SOURCES = [
+  'userscript.js',
+  'gtm.js',
+  'googletagmanager',
+  'google-analytics',
+  'analytics.js',
+  'clarity.js',
+  'clarity.ms',
+  'paddle.js',
+  'cdn.paddle.com',
+  'zaraz',
+  'cloudflareinsights',
+];
+
+function isThirdPartyError(err) {
+  const haystack = `${err?.message || ''}\n${err?.stack || ''}`;
+  return THIRD_PARTY_ERROR_SOURCES.some((src) => haystack.includes(src));
+}
+
+test.beforeEach(async ({ page }) => {
+  page.on('pageerror', (err) => {
+    if (isThirdPartyError(err)) return;
+    throw err;
+  });
+  // M04: keep the Onboarding / Support-pledge one-time modals from trapping focus.
+  await suppressOneTimeModals(page);
+});
+
+/** Navigate to the EDITOR with a clean localStorage slate (export.spec.js pattern). */
+async function gotoFresh(page) {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await openEditor(page);
+}
+
+/**
+ * Seed ONE item via the HomeView JSON-import path and OPEN it in the editor.
+ *
+ * Why import (not type): the non-plain CSS modes are Plus-gated on *user edits* for a
+ * signed-out user (cssGated → sign-in modal, change withheld). handleImport writes
+ * the item fields verbatim, and handleOpenItem → loadItem reloads them WITHOUT
+ * touching cssGated — so the boot-time transpile effect runs on the seeded
+ * cssMode/css and the preview reflects the COMPILED css. Returns the seeded id.
+ */
+async function importAndOpen(page, item) {
+  await gotoHome(page);
+  const payload = JSON.stringify({ items: [item] });
+  await page.locator('[data-testid="lib-import-input"]').setInputFiles({
+    name: 'seed.json',
+    mimeType: 'application/json',
+    buffer: Buffer.from(payload, 'utf-8'),
+  });
+  // Re-navigate so a fresh useItems mount reads the updated local index, then open
+  // the card (handleOpenItem → loadItem → navigate to ?id=).
+  await gotoHome(page);
+  const card = page.locator(`[data-testid="home-card-${item.id}"]`);
+  await expect(card).toBeVisible({ timeout: 10_000 });
+  await card.click();
+  await expect(
+    page.locator('[data-testid="dsl-editor"] .cm-content'),
+  ).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+/** Build a minimal importable Item with the given css fields. */
+function seedItem({ id, cssMode, css = '', html = '', cssSettings }) {
+  return {
+    id,
+    title: `seed-${cssMode}`,
+    js: 'Alice -> Bob: Hello',
+    css,
+    html,
+    htmlMode: 'html',
+    cssMode,
+    jsMode: 'js',
+    ...(cssSettings !== undefined ? { cssSettings } : {}),
+    updatedOn: Date.now(),
+  };
+}
+
+/**
+ * Poll the preview iframe's user-CSS rail (#zenumlstyle) and return its raw
+ * textContent. computeCss output is pushed there as the <style> textContent via the
+ * 'updateCss' postMessage. We read textContent directly (NOT toContainText): a
+ * <style> element carries no *rendered* visible text, so Playwright's text matchers
+ * see "" even when innerHTML holds the compiled CSS. expect.poll over this getter
+ * gives the same auto-retry while reading the real node content.
+ */
+async function readZenumlStyle(page) {
+  return page
+    .frameLocator('[data-testid="preview-iframe"]')
+    .locator('#zenumlstyle')
+    .textContent();
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// CSS-1: the Custom-CSS pane expands from its strip and collapses from its footer.
+// ──────────────────────────────────────────────────────────────────────────────
+test('CSS-1 the Custom-CSS pane expands from its strip and collapses from its footer', async ({
+  page,
+}) => {
+  await gotoFresh(page);
+
+  // Fresh diagram → empty CSS → the panel renders collapsed as a thin strip.
+  const strip = page.locator('[data-testid="css-panel-strip"]');
+  const expanded = page.locator('[data-testid="css-panel-expanded"]');
+  const collapse = page.locator('[data-testid="css-panel-collapse"]');
+
+  await expect(strip).toBeVisible();
+  await expect(strip).toHaveAttribute('aria-expanded', 'false');
+  await expect(expanded).toHaveCount(0);
+
+  // Expand from the strip → the expanded body + the CSS editor surface appear.
+  await strip.click();
+  await expect(expanded).toBeVisible();
+  await expect(
+    page.locator('[data-testid="css-editor"] .cm-content'),
+  ).toBeVisible();
+  await expect(collapse).toHaveAttribute('aria-expanded', 'true');
+  await expect(strip).toHaveCount(0);
+
+  // Collapse from the footer control → back to the strip, body gone.
+  await collapse.click();
+  await expect(strip).toBeVisible();
+  await expect(expanded).toHaveCount(0);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// CSS-2: the CSS mode select offers CSS / SCSS / Sass / Less / Stylus / ACSS.
+// ──────────────────────────────────────────────────────────────────────────────
+test('CSS-2 the CSS mode select offers CSS/SCSS/Sass/Less/Stylus/Atomic CSS', async ({
+  page,
+}) => {
+  await gotoFresh(page);
+
+  // Expand the CSS pane to reach the pre-processor mode Select.
+  await page.locator('[data-testid="css-panel-strip"]').click();
+  const modeSelect = page.locator('[data-testid="css-mode-select"]');
+  await expect(modeSelect).toBeVisible();
+  // Default plain mode reads "CSS".
+  await expect(modeSelect).toContainText('CSS');
+
+  // Opening the Radix dropdown is NOT gated (only PICKING a non-css option is), so
+  // the full pre-processor roster is assertable for a signed-out user.
+  await modeSelect.click();
+  for (const label of ['CSS', 'SCSS', 'Sass', 'Less', 'Stylus', 'Atomic CSS']) {
+    await expect(
+      page.getByRole('option', { name: label, exact: true }),
+    ).toBeVisible();
+  }
+
+  // Close the dropdown without selecting (Escape) — picking SCSS here would trip the
+  // signed-out sign-in gate, which CSS-2 isn't about.
+  await page.keyboard.press('Escape');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// CSS-3: entering SCSS (and Less) source transpiles so the preview reflects the
+// COMPILED css. Seeded via import to bypass the signed-out user-edit gate; the
+// transpile effect runs on the seeded cssMode/css regardless of auth.
+// ──────────────────────────────────────────────────────────────────────────────
+test('CSS-3 SCSS source transpiles so the preview reflects compiled CSS', async ({
+  page,
+}) => {
+  test.skip(
+    !!process.env.PW_BASE_URL,
+    'reads the preview iframe + seeds via a hidden file input — local app only',
+  );
+
+  // SCSS that ONLY compiles to plain CSS via the transpiler: a nested rule plus a
+  // variable. If sass did NOT run, `#zenumlstyle` would carry the raw `$accent`/
+  // nesting source (or nothing), never the flattened `.zenuml-label { color: ... }`.
+  const SCSS =
+    '$accent: rgb(10, 20, 30);\n.zenuml-label {\n  color: $accent;\n}\n';
+  await importAndOpen(
+    page,
+    seedItem({ id: 'css3-scss', cssMode: 'scss', css: SCSS }),
+  );
+
+  // The compiled CSS lands in the iframe's #zenumlstyle. sass flattens the nesting
+  // and resolves the variable (sass KEEPS rgb() — verified: compileString emits
+  // `.zenuml-label {\n  color: rgb(10, 20, 30);\n}`). Assert the FLAT compiled
+  // selector + resolved value, and that the raw SCSS variable token is absent
+  // (proving compilation ran, not raw passthrough).
+  await expect
+    .poll(() => readZenumlStyle(page), { timeout: 15_000 })
+    .toContain('.zenuml-label');
+  const compiled = await readZenumlStyle(page);
+  expect(compiled).toContain('color: rgb(10, 20, 30)');
+  expect(compiled).not.toContain('$accent');
+});
+
+test('CSS-3 Less source transpiles so the preview reflects compiled CSS', async ({
+  page,
+}) => {
+  test.skip(
+    !!process.env.PW_BASE_URL,
+    'reads the preview iframe + seeds via a hidden file input — local app only',
+  );
+
+  // Less with a variable; less.render resolves @brand and emits flat CSS. less
+  // NORMALIZES rgb(40, 50, 60) to the hex form #28323c (verified: less.render emits
+  // `.zenuml-label {\n  color: #28323c;\n}`) — that normalization is itself proof the
+  // Less compiler ran (a raw passthrough would keep `@brand` / `rgb(...)`).
+  const LESS =
+    '@brand: rgb(40, 50, 60);\n.zenuml-label {\n  color: @brand;\n}\n';
+  await importAndOpen(
+    page,
+    seedItem({ id: 'css3-less', cssMode: 'less', css: LESS }),
+  );
+
+  await expect
+    .poll(() => readZenumlStyle(page), { timeout: 15_000 })
+    .toContain('.zenuml-label');
+  const compiled = await readZenumlStyle(page);
+  expect(compiled).toContain('color: #28323c');
+  expect(compiled).not.toContain('@brand');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// CSS-4: ACSS mode reveals the Atomic-CSS settings entry, which opens the
+// AtomicCssSettingsModal. Seeded via import (acss mode is Plus-gated on edits).
+// ──────────────────────────────────────────────────────────────────────────────
+test('CSS-4 ACSS mode reveals the Atomic-CSS settings entry that opens the modal', async ({
+  page,
+}) => {
+  test.skip(
+    !!process.env.PW_BASE_URL,
+    'seeds via a hidden file input — local app only',
+  );
+
+  // Seed an ACSS item. acssConfig is a JSON *string* (transpilers.ts JSON.parses it);
+  // html carries the atomic class names atomizer scans. The CSS editor is read-only
+  // in acss mode, so config is edited via the revealed settings button.
+  await importAndOpen(
+    page,
+    seedItem({
+      id: 'css4-acss',
+      cssMode: 'acss',
+      html: '<div class="D(b) C(#0a141e)">x</div>',
+      cssSettings: { acssConfig: '{}' },
+    }),
+  );
+
+  // Expand the CSS pane → in acss mode the headerControls reveal the settings entry.
+  await page.locator('[data-testid="css-panel-strip"]').click();
+  const settingsOpen = page.locator('[data-testid="acss-settings-open"]');
+  await expect(settingsOpen).toBeVisible();
+
+  // The Atomic-CSS-config modal is not open yet.
+  await expect(page.locator('[data-testid="acss-modal"]')).toHaveCount(0);
+
+  // Clicking it opens the AtomicCssSettingsModal with its config textarea.
+  await settingsOpen.click();
+  await expect(page.locator('[data-testid="acss-modal"]')).toBeVisible();
+  await expect(page.locator('[data-testid="acss-config"]')).toBeVisible();
+
+  // Escape closes it (proving the wired Dialog).
+  await page.keyboard.press('Escape');
+  await expect(page.locator('[data-testid="acss-modal"]')).toHaveCount(0);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// CSS-5: non-plain CSS mode gated behind Plus for a FREE signed-in user → pricing.
+// Needs the Firebase emulator (auth) — deferred to the staging gate, mirroring
+// cloud.fixme.spec.js CSS-5.
+// ──────────────────────────────────────────────────────────────────────────────
+test.fixme(
+  'CSS-5 — needs: emulator (auth) — non-plain CSS mode gated behind Plus for free users (→ pricing)',
+  async () => {
+    // Free signed-in user (signInViaEmulator), expand the CSS pane, pick SCSS in
+    // css-mode-select → cssGated() opens the pricing modal (pricing-modal visible).
+  },
+);
+
+// ──────────────────────────────────────────────────────────────────────────────
+// CSS-6: Prettier-format (Ctrl/Cmd+Shift+F) reformats the CSS buffer.
+//
+// The Mod-Shift-f binding runs formatCss(prettier) and dispatches the result into
+// the CM doc — but that dispatch fires @uiw's updateListener → onChange →
+// handleSetCss, which for a SIGNED-OUT user routes through cssGated() and WITHHOLDS
+// the store write. @uiw is a CONTROLLED editor on the parent `value`, so it reverts
+// the buffer to the (still-empty) store value — the reformatted text is never
+// observable without a Plus session. (For a Plus signed-in user the write lands and
+// the buffer shows the reformatted CSS.) Needs emulator auth → test.fixme.
+// ──────────────────────────────────────────────────────────────────────────────
+test.fixme(
+  'CSS-6 — needs: emulator (Plus auth) — Ctrl+Shift+F reformats the CSS buffer',
+  async () => {
+    // Plus signed-in user: switch css-mode (or stay css), type unformatted CSS such
+    // as `.a{color:red}` into css-editor, press Mod-Shift-f → the buffer reformats to
+    // prettier output (`.a {\n  color: red;\n}`). For a signed-out user the gate
+    // withholds the css write and @uiw reverts the buffer, so the reformat is not
+    // observable — hence this is auth-gated, not implementable locally.
+  },
+);

--- a/e2e/tests/export.spec.js
+++ b/e2e/tests/export.spec.js
@@ -1,0 +1,329 @@
+// Export / Import variants (EXP-1..EXP-5 from e2e/E2E_GAP_TEST_PLAN.md §12).
+//
+// Signed-out / local flows only. The export-all (JSON) + import-JSON happy paths
+// are already covered by library.spec.js; this spec covers the REMAINING export /
+// import variants: HTML export, malformed-import error surfacing, and merge dedup.
+//
+// SURFACE NOTES (verified against web/src/** on 2026-06-18):
+//   - PNG / SVG export (EXP-1 / EXP-2): there is NO UI that exports the diagram to
+//     PNG or SVG. PreviewFrame exposes a `getPng()` imperative handle
+//     (web/src/preview/PreviewFrame.tsx:221) but NOTHING calls it — grep finds zero
+//     download of a `.png`/`.svg` file anywhere in web/src. RendererHeader hosts
+//     only Present + (optional) Fit. So these two cases have no implementable UI
+//     today → test.fixme with the exact reason (not test.skip; the gap is real,
+//     not environment-conditional).
+//   - Export-as-HTML (EXP-3): DiagramCard's kebab → "Export as HTML"
+//     (web/src/components/home/DiagramCard.tsx:107) → AppRoot.handleExportHtml →
+//     downloadText(`${safe}.html`, buildStandaloneHtml(item), 'text/html')
+//     (AppRoot.tsx:821). buildStandaloneHtml (services/exportImport.ts) embeds the
+//     DSL inline + loads @zenuml/core from the jsDelivr CDN — a self-contained file.
+//   - Malformed import (EXP-4): the HomeView header's ImportExportBar feeds the
+//     file text to AppRoot.handleImport, which try/catches parseImportJson (throws
+//     on invalid JSON) and calls setImportError → a ConfirmDialog titled
+//     "Import failed" (AppRoot.tsx:972) — i.e. an explicit error dialog, not silent.
+//   - Merge dedup (EXP-5): handleImport builds `map[it.id] = it`, so an imported id
+//     that already exists OVERWRITES rather than appends — the row count only grows
+//     by the number of genuinely-new ids.
+//
+// GUARDS: HTML export issues a real browser download, and the import cases drive a
+// hidden <input type=file> via setInputFiles — both only meaningful against the
+// local app, so they self-skip on the remote staging gate (PW_BASE_URL set), the
+// same convention production-build.spec.js uses.
+
+import { test, expect } from '@playwright/test';
+import { suppressOneTimeModals } from './helpers/onetime';
+import { openEditor, gotoHome } from './helpers/hub';
+
+const selectAll = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
+
+// Deployed sites load third-party analytics/CDN scripts that throw uncaught errors
+// we don't own; treat those as noise (copied verbatim from smoke/library specs).
+const THIRD_PARTY_ERROR_SOURCES = [
+  'userscript.js',
+  'gtm.js',
+  'googletagmanager',
+  'google-analytics',
+  'analytics.js',
+  'clarity.js',
+  'clarity.ms',
+  'paddle.js',
+  'cdn.paddle.com',
+  'zaraz',
+  'cloudflareinsights',
+];
+
+function isThirdPartyError(err) {
+  const haystack = `${err?.message || ''}\n${err?.stack || ''}`;
+  return THIRD_PARTY_ERROR_SOURCES.some((src) => haystack.includes(src));
+}
+
+test.beforeEach(async ({ page }) => {
+  page.on('pageerror', (err) => {
+    if (isThirdPartyError(err)) return;
+    throw err;
+  });
+  // M04: keep the Onboarding / Support-pledge one-time modals from trapping focus.
+  await suppressOneTimeModals(page);
+});
+
+function editorLocator(page) {
+  return page.locator('[data-testid="dsl-editor"] .cm-content');
+}
+
+/** Navigate to the EDITOR with a clean localStorage slate (library.spec.js pattern). */
+async function gotoFresh(page) {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await openEditor(page);
+}
+
+/** Type a replacement DSL into the CM6 editor (select-all → Delete → type). */
+async function typeDsl(page, dsl, { timeout = 15_000 } = {}) {
+  const editor = editorLocator(page);
+  await expect(editor).toBeVisible({ timeout });
+  await editor.click();
+  await page.keyboard.press(selectAll);
+  await page.keyboard.press('Delete');
+  await editor.pressSequentially(dsl);
+}
+
+/** Set the diagram title via the header title field. */
+async function setTitle(page, title) {
+  const titleInput = page.locator('[data-testid="header-title"]');
+  await expect(titleInput).toBeVisible();
+  await titleInput.click();
+  await page.keyboard.press(selectAll);
+  await page.keyboard.press('Delete');
+  await titleInput.pressSequentially(title);
+  await expect(titleInput).toHaveValue(title);
+}
+
+/**
+ * The FIRST signed-out Save opens a one-time "Saved on this device" notice (a Radix
+ * Dialog whose overlay intercepts the next click). gotoFresh clears localStorage, so
+ * loginAndSaveMessageSeen is false → the first save in each test shows it with
+ * certainty; dismiss via its "Not now" button (data-testid="confirm-cancel").
+ * (Inlined from library.spec.js — sibling agents edit the shared helpers in parallel.)
+ */
+async function dismissSaveNoticeIfPresent(page, { expected = false } = {}) {
+  const cancel = page.locator('[data-testid="confirm-cancel"]');
+  if (expected) {
+    await expect(cancel).toBeVisible();
+  } else if (!(await cancel.isVisible().catch(() => false))) {
+    return;
+  }
+  await cancel.click();
+  await expect(cancel).toBeHidden();
+}
+
+/** Seed one local item: set title + DSL, then Save (writes the local item index). */
+async function seedItem(page, { title, dsl, firstSave = false }) {
+  await setTitle(page, title);
+  await typeDsl(page, dsl);
+  await expect(editorLocator(page)).toContainText(dsl.split('\n')[0]);
+  await page.locator('[data-testid="header-menu"]').click();
+  await page.locator('[data-testid="header-save"]').click();
+  await dismissSaveNoticeIfPresent(page, { expected: firstSave });
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// EXP-1: Export PNG downloads a *.png.
+//
+// FIXME — no PNG export UI exists. PreviewFrame.getPng() is implemented but has no
+// caller; nothing in web/src downloads a .png. Cannot be exercised without first
+// building the export-to-PNG control (a product gap, not a test-env limitation).
+// ──────────────────────────────────────────────────────────────────────────────
+test.fixme(
+  'EXP-1 export PNG downloads a .png — no PNG export UI exists yet (PreviewFrame.getPng has no caller)',
+  async () => {},
+);
+
+// ──────────────────────────────────────────────────────────────────────────────
+// EXP-2: Export SVG downloads a *.svg.
+//
+// FIXME — no SVG export UI exists. There is no SVG download path anywhere in
+// web/src (the renderer side only exposes Present/Fit). Same product gap as EXP-1.
+// ──────────────────────────────────────────────────────────────────────────────
+test.fixme(
+  'EXP-2 export SVG downloads a .svg — no SVG export UI exists yet',
+  async () => {},
+);
+
+// ──────────────────────────────────────────────────────────────────────────────
+// EXP-3: Export-as-HTML produces a self-contained *.html.
+// ──────────────────────────────────────────────────────────────────────────────
+test('EXP-3 card "Export as HTML" downloads a self-contained .html file', async ({
+  page,
+}) => {
+  test.skip(
+    !!process.env.PW_BASE_URL,
+    'HTML export reads the downloaded file off disk — local app only',
+  );
+
+  await gotoFresh(page);
+
+  // Seed a distinctive item so the exported HTML embeds known DSL we can assert on.
+  const UNIQUE_PARTICIPANT = 'ExportHtmlProbe';
+  await seedItem(page, {
+    title: 'HtmlExportDiagram',
+    dsl: `${UNIQUE_PARTICIPANT}\nUser\nUser->${UNIQUE_PARTICIPANT}: standaloneExport`,
+    firstSave: true,
+  });
+
+  // The HTML export lives on the HomeView card's kebab menu.
+  await gotoHome(page);
+  const card = page.locator('[data-testid^="home-card-"]').first();
+  await expect(card).toBeVisible({ timeout: 10_000 });
+
+  // The kebab trigger is revealed on hover (opacity-0 group-hover). Hover the card,
+  // then open its "Diagram options" menu.
+  await card.hover();
+  await card.getByRole('button', { name: 'Diagram options' }).click();
+
+  // Click "Export as HTML" and capture the download it triggers.
+  const downloadPromise = page.waitForEvent('download', { timeout: 10_000 });
+  await page.getByRole('menuitem', { name: 'Export as HTML' }).click();
+  const download = await downloadPromise;
+
+  // Filename is `${slug(title)}.html` (AppRoot.handleExportHtml).
+  expect(download.suggestedFilename()).toMatch(/\.html$/);
+  expect(download.suggestedFilename()).toBe('htmlexportdiagram.html');
+
+  // Read the file off disk and assert it is SELF-CONTAINED: it embeds the diagram
+  // DSL inline AND pulls @zenuml/core from a CDN (so it renders with no local server).
+  const path = await download.path();
+  const fs = await import('fs');
+  const html = fs.readFileSync(path, 'utf-8');
+  expect(html).toContain('<!doctype html>');
+  expect(html).toContain(UNIQUE_PARTICIPANT); // the DSL is embedded, not referenced
+  expect(html).toContain('mounting-point'); // the @zenuml/core mount scaffold
+  expect(html).toMatch(/cdn\.jsdelivr\.net\/npm\/@zenuml\/core/); // CDN-loaded core
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// EXP-4: Importing malformed JSON shows an error dialog (not silent).
+// ──────────────────────────────────────────────────────────────────────────────
+test('EXP-4 importing malformed JSON shows an "Import failed" error dialog', async ({
+  page,
+}) => {
+  test.skip(
+    !!process.env.PW_BASE_URL,
+    'drives a hidden file input via setInputFiles — local app only',
+  );
+
+  await gotoFresh(page);
+
+  // Go to the HomeView hub where the ImportExportBar (and its import-error dialog)
+  // lives. An empty library still renders the import control.
+  await gotoHome(page);
+
+  // The "Import failed" ConfirmDialog must NOT be present before we import.
+  const errorDialog = page
+    .getByRole('dialog')
+    .filter({ hasText: 'Import failed' });
+  await expect(errorDialog).toHaveCount(0);
+
+  // Feed the hidden file input a file that is NOT valid JSON. parseImportJson does
+  // JSON.parse(text) which throws; handleImport catches it → setImportError → dialog.
+  await page.locator('[data-testid="lib-import-input"]').setInputFiles({
+    name: 'broken.json',
+    mimeType: 'application/json',
+    buffer: Buffer.from('{ this is not valid json ]]', 'utf-8'),
+  });
+
+  // The error is surfaced as a dialog (title "Import failed") — not swallowed.
+  await expect(errorDialog).toBeVisible({ timeout: 10_000 });
+
+  // It is dismissible via its OK button (confirm-ok), proving the wired action path.
+  await page.locator('[data-testid="confirm-ok"]').click();
+  await expect(errorDialog).toHaveCount(0);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// EXP-5: Importing an overlapping set skips duplicate IDs (only new rows added).
+// ──────────────────────────────────────────────────────────────────────────────
+test('EXP-5 importing an overlapping set skips duplicate IDs — only new rows added', async ({
+  page,
+}) => {
+  test.skip(
+    !!process.env.PW_BASE_URL,
+    'drives a hidden file input via setInputFiles — local app only',
+  );
+
+  await gotoFresh(page);
+
+  // Seed one pre-existing item, then read back its REAL id from the home-card testid.
+  await seedItem(page, {
+    title: 'OriginalDiagram',
+    dsl: 'OrigA\nOrigB\nOrigA->OrigB: original',
+    firstSave: true,
+  });
+
+  await gotoHome(page);
+  await expect(page.locator('[data-testid="home-grid"]')).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(page.locator('[data-testid^="home-card-"]')).toHaveCount(1);
+
+  // Extract the seeded item's id from its card testid (home-card-<id>).
+  const seededTestId = await page
+    .locator('[data-testid^="home-card-"]')
+    .first()
+    .getAttribute('data-testid');
+  const seededId = seededTestId.replace('home-card-', '');
+  expect(seededId.length).toBeGreaterThan(0);
+
+  // Build an import payload that OVERLAPS the seeded id (a duplicate) AND adds one
+  // genuinely new id. handleImport keys items by id (map[it.id] = it), so the
+  // duplicate overwrites the existing row rather than creating a second copy — the
+  // grid should grow by exactly ONE (the new id), not two.
+  const newId = 'exp5-brand-new-item';
+  const payload = JSON.stringify({
+    items: [
+      {
+        id: seededId, // DUPLICATE of the already-saved item
+        title: 'OriginalDiagram (re-imported)',
+        js: 'OrigA\nOrigB\nOrigA->OrigB: reimported',
+        css: '',
+        html: '',
+        htmlMode: 'html',
+        cssMode: 'css',
+        jsMode: 'js',
+        updatedOn: Date.now(),
+      },
+      {
+        id: newId, // genuinely NEW
+        title: 'FreshlyImportedDiagram',
+        js: 'NewA\nNewB\nNewA->NewB: fresh',
+        css: '',
+        html: '',
+        htmlMode: 'html',
+        cssMode: 'css',
+        jsMode: 'js',
+        updatedOn: Date.now(),
+      },
+    ],
+  });
+
+  await page.locator('[data-testid="lib-import-input"]').setInputFiles({
+    name: 'overlap.json',
+    mimeType: 'application/json',
+    buffer: Buffer.from(payload, 'utf-8'),
+  });
+
+  // Re-navigate so a fresh useItems mount reads the updated local index.
+  await gotoHome(page);
+
+  // The new item appears; the original is still there exactly once. Total = 2, NOT 3
+  // — the duplicate id was merged (overwritten), not appended as a new row.
+  await expect(
+    page.getByText('FreshlyImportedDiagram', { exact: true }),
+  ).toBeVisible({ timeout: 10_000 });
+  await expect(
+    page.locator(`[data-testid="home-card-${newId}"]`),
+  ).toBeVisible();
+  await expect(
+    page.locator(`[data-testid="home-card-${seededId}"]`),
+  ).toHaveCount(1);
+  await expect(page.locator('[data-testid^="home-card-"]')).toHaveCount(2);
+});

--- a/e2e/tests/header.spec.js
+++ b/e2e/tests/header.spec.js
@@ -1,0 +1,217 @@
+// Header / title E2E (signed-out / local flows only). Covers the gap-plan §14
+// rows that are runnable WITHOUT the Firebase emulator:
+//   HDR-1  inline title edit commits the typed title (Enter).
+//   HDR-5  the "Your diagrams" breadcrumb returns to the hub (/?view=diagrams).
+//
+// HONEST GAPS (verified against the code + the live app, NOT assumed):
+//   HDR-2 (Escape reverts the title) — NOT IMPLEMENTED. The header title is a plain
+//     CONTROLLED <input> (web/src/components/header/AppHeader.tsx → TextInput, bound
+//     to onTitleChange=setTitle). onChange fires setTitle on EVERY keystroke, so the
+//     store already holds the typed value before Escape; there is no draft buffer and
+//     no onKeyDown/Escape handler to revert to a snapshot. Probed live: typing
+//     "TempEscapeTitle" then Escape leaves the field at "TempEscapeTitle" (no revert).
+//     → test.fixme: the revert behavior the case asserts does not exist in the product.
+//   HDR-3 (unsaved marker appears on edit, clears on save) — needs AUTH. The savestate
+//     indicator (data-testid="header-savestate") has precedence !signedIn → 'local'
+//     ABOVE the dirty branch (AppHeader.tsx SaveState), so a SIGNED-OUT user always
+//     reads "Local only" and NEVER shows the amber "Unsaved" marker — even though the
+//     store's `dirty` flips true. Probed live: after editing the title the indicator
+//     stays data-state="local". So BOTH halves (marker-on-edit AND clear-on-save) of
+//     this case require a signed-in session. → test.fixme with that reason.
+//   HDR-4 (fork) / HDR-6 (profile menu) — need cloud/auth → test.fixme per the plan.
+//
+// Conventions mirror smoke/modals/persistence/library specs: the third-party
+// pageerror filter, suppressOneTimeModals in beforeEach, openEditor/gotoHome.
+
+import { test, expect } from '@playwright/test';
+import { suppressOneTimeModals } from './helpers/onetime';
+import { openEditor, gotoHome } from './helpers/hub';
+
+const selectAll = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
+
+// Deployed sites (staging/prod, via PW_BASE_URL) load third-party analytics/CDN
+// scripts that throw uncaught errors we don't own; treat those as noise so this
+// spec stays usable against the live staging E2E gate (copied from smoke.spec.js).
+const THIRD_PARTY_ERROR_SOURCES = [
+  'userscript.js',
+  'gtm.js',
+  'googletagmanager',
+  'google-analytics',
+  'analytics.js',
+  'clarity.js',
+  'clarity.ms',
+  'paddle.js',
+  'cdn.paddle.com',
+  'zaraz',
+  'cloudflareinsights',
+];
+
+function isThirdPartyError(err) {
+  const haystack = `${err?.message || ''}\n${err?.stack || ''}`;
+  return THIRD_PARTY_ERROR_SOURCES.some((src) => haystack.includes(src));
+}
+
+/** Navigate to the EDITOR with a clean localStorage slate (see persistence.spec.js). */
+async function gotoFresh(page) {
+  // M04: seed only the one-time-modal flags (onboarded / lastSeenVersion) so the
+  // Onboarding/Support-pledge dialogs don't trap focus and intercept the header
+  // clicks these tests drive. localStorage.clear() below wipes user data; the init
+  // script re-seeds those two flags on the subsequent goto.
+  await suppressOneTimeModals(page);
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  // Editor-as-landing: bare '/' boots the editor (cleared storage → seeds a fresh
+  // sample diagram), so openEditor lands straight on the CM6 surface here.
+  await openEditor(page);
+}
+
+/** The header title <input>. */
+function titleInput(page) {
+  return page.locator('[data-testid="header-title"]');
+}
+
+/** Replace the header title with `value` (select-all → Delete → type). */
+async function setTitle(page, value) {
+  const title = titleInput(page);
+  await expect(title).toBeVisible();
+  await title.click();
+  await page.keyboard.press(selectAll);
+  await page.keyboard.press('Delete');
+  await title.pressSequentially(value);
+}
+
+test.beforeEach(async ({ page }) => {
+  // Fail the test on genuine uncaught app errors, except known third-party noise.
+  page.on('pageerror', (err) => {
+    if (isThirdPartyError(err)) return;
+    throw err;
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// HDR-1: inline title edit — focus the title, type, Enter commits the new title.
+//
+// The commit is asserted TWO ways so this isn't a bare echo-back of the input:
+//   1. after Enter the field holds the typed value (the input committed it), and
+//   2. saving the diagram and opening the hub shows a card carrying the new title —
+//      proving Enter committed the value into the actual item, not just the field.
+// ──────────────────────────────────────────────────────────────────────────────
+test('HDR-1: typing a title and pressing Enter commits the new title', async ({
+  page,
+}) => {
+  await gotoFresh(page);
+
+  const title = titleInput(page);
+  await expect(title).toBeVisible();
+  // The starter item titles to "Untitled"; assert we start from a different value so
+  // the change below is a real edit, not a coincidence.
+  await expect(title).toHaveValue('Untitled');
+
+  const NEW_TITLE = 'HeaderCommitDiagram';
+  await setTitle(page, NEW_TITLE);
+  // Enter commits the edit. (The field is a controlled input bound to setTitle, so the
+  // value persists across the Enter — Enter must NOT clear or revert it.)
+  await page.keyboard.press('Enter');
+  await expect(title).toHaveValue(NEW_TITLE);
+
+  // Save the diagram (signed-out, local). Save lives in the header overflow menu; the
+  // FIRST signed-out save opens the one-time "Saved on this device" notice — dismiss it.
+  await page.locator('[data-testid="header-menu"]').click();
+  await page.locator('[data-testid="header-save"]').click();
+  const noticeCancel = page.locator('[data-testid="confirm-cancel"]');
+  await expect(noticeCancel).toBeVisible();
+  await noticeCancel.click();
+  await expect(noticeCancel).toBeHidden();
+
+  // The committed title rode into the saved item: the hub card carries it. A FULL
+  // navigation to the hub freshly mounts useItems, so this reads the persisted index.
+  await gotoHome(page);
+  await expect(page.locator('[data-testid="home-grid"]')).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(page.getByText(NEW_TITLE, { exact: true })).toBeVisible();
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// HDR-5: the "← Your diagrams" breadcrumb returns to the hub (/?view=diagrams).
+//
+// onGoHome is always wired in editor mode (AppRoot passes onGoHome={goHome}), so the
+// breadcrumb renders for any editor view. Clicking it navigates to ?view=diagrams and
+// renders the HomeView hub — asserted via BOTH the URL and the home-view surface.
+// ──────────────────────────────────────────────────────────────────────────────
+test('HDR-5: the "Your diagrams" breadcrumb returns to the hub', async ({
+  page,
+}) => {
+  await gotoFresh(page);
+
+  // The breadcrumb (back arrow + "Your diagrams") is present in the editor header.
+  const breadcrumb = page.locator('[data-testid="hub-breadcrumb"]');
+  await expect(breadcrumb).toBeVisible();
+  const goHome = page.locator('[data-testid="header-go-home"]');
+  await expect(goHome).toBeVisible();
+  await expect(goHome).toHaveAttribute('aria-label', 'Back to your diagrams');
+
+  // Click it → lands on the hub at ?view=diagrams.
+  await goHome.click();
+
+  await expect(page.locator('[data-testid="home-view"]')).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page).toHaveURL(/\?view=diagrams/);
+  // And the editor surface is no longer mounted (we left the editor for the hub).
+  await expect(page.locator('[data-testid="dsl-editor"]')).toHaveCount(0);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// HDR-2: title edit Escape cancels / reverts.
+//
+// NOT IMPLEMENTED (verified): the header title is a controlled <input> bound to
+// setTitle on every keystroke (AppHeader.tsx → TextInput; editorStore.setTitle). There
+// is no draft snapshot and no Escape/onKeyDown handler, so Escape cannot revert — a
+// live probe typing "TempEscapeTitle" then Escape leaves the field unchanged. Asserting
+// a revert would be asserting behavior the product does not have. Marked fixme until a
+// revert-on-Escape affordance is added (a draft buffer committed on Enter/blur and
+// discarded on Escape).
+test.fixme(
+  'HDR-2: pressing Escape reverts an in-progress title edit',
+  async () => {
+    // Intentionally empty: the revert behavior does not exist yet (see comment above).
+    // Implement once the title field gains a draft buffer + Escape→revert handler.
+  },
+);
+
+// ──────────────────────────────────────────────────────────────────────────────
+// HDR-3: an unsaved marker appears on edit and clears after Save.
+//
+// Needs AUTH (verified): the savestate indicator's precedence is
+// !signedIn → 'local' ABOVE the dirty branch (AppHeader.tsx SaveState), so a
+// SIGNED-OUT session always renders "Local only" and never the amber "Unsaved"
+// marker — even though editorStore.dirty flips true on edit (live-probed:
+// data-state stays "local" after a title edit). Both halves of this case
+// (marker-on-edit AND clear-on-save) therefore require a signed-in session
+// (Firebase Auth emulator / seeded account), which the signed-out staging gate
+// lacks. Once auth is available: edit → assert data-state="dirty" ("Unsaved") →
+// save → assert data-state="saved".
+test.fixme(
+  'HDR-3: unsaved marker appears on edit and clears after save (signed-in)',
+  async () => {
+    // Intentionally empty: the dirty/Unsaved indicator is auth-gated (see comment).
+  },
+);
+
+// ──────────────────────────────────────────────────────────────────────────────
+// HDR-4: Fork button duplicates the current item into an owned copy.
+// Needs cloud/auth (the gap plan marks HDR-4 as CLOUD) → deferred.
+test.fixme(
+  'HDR-4: Fork duplicates the current item into an owned copy',
+  async () => {
+    // Intentionally empty: fork-to-owned-copy needs a signed-in cloud session.
+  },
+);
+
+// ──────────────────────────────────────────────────────────────────────────────
+// HDR-6: signed-out header shows "Sign in"; signed-in shows the profile menu.
+// The signed-in half needs AUTH (the gap plan marks HDR-6 as AUTH) → deferred.
+test.fixme('HDR-6: signed-in header shows the profile menu', async () => {
+  // Intentionally empty: the signed-in profile menu needs a signed-in session.
+});

--- a/e2e/tests/library-actions.spec.js
+++ b/e2e/tests/library-actions.spec.js
@@ -1,0 +1,468 @@
+// Library / Hub actions E2E (signed-out / local flows only).
+//
+// Covers the per-card kebab actions and grid-level affordances on the HomeView
+// hub (reached at '/?view=diagrams' under editor-as-landing, 2026-06-13):
+//
+//   LIB-1  kebab → Duplicate  → returning to the hub shows a second "(Forked) …" card
+//   LIB-2  kebab → Delete     → the card disappears from the grid
+//   LIB-3  kebab → Export HTML → triggers a *.html download (local-build only)
+//   LIB-4  sort Recent ↔ Title → reorders the grid
+//   LIB-5  a card shows its DSL preview + title + last-updated date
+//   LIB-6  hub "New" CTA       → opens a blank editor
+//   LIB-8  empty hub           → "No diagrams yet" + New / Browse-templates CTAs
+//
+// Selectors are REAL (grepped from web/src/components/home/{HomeView,DiagramCard}.tsx
+// and web/src/ui/{Menu,Select}.tsx):
+//   - Cards:        [data-testid^="home-card-"] (DiagramCard root; the only testid).
+//   - Kebab menu:   a Radix DropdownMenu — trigger is the per-card button
+//                   aria-label="Diagram options"; items carry NO testid, so we
+//                   target them by their visible text (Duplicate / Delete /
+//                   "Export as HTML"), the stable contract.
+//   - Sort:         Radix Select [data-testid="home-sort"]; options render as
+//                   role=option named "Recent"/"Title" (Recent = updated desc).
+//   - Empty state:  [data-testid="home-empty"], home-empty-new, home-empty-templates.
+//   - New CTA:      [data-testid="home-new"] (split-button primary).
+//
+// Seeding mirrors library.spec.js exactly: seed items in the EDITOR (bare '/' boots
+// it; openEditor), then read the library back via a FULL navigation to
+// '/?view=diagrams' (gotoHome) so a fresh useItems mount re-reads localItems.
+//
+// handleForkItem (AppRoot) loads + forks (title → "(Forked) …", dirty) and switches
+// to the editor — a fork is UNOWNED until explicitly saved, so LIB-1 must Save the
+// fork in the editor before it appears as a second hub card. handleDeleteItem runs
+// itemService.removeItem immediately with NO confirm dialog for home cards (the
+// ConfirmDialogs in the tree are for folders/pages/editor); LIB-2 still handles a
+// confirm conditionally per the plan's "with confirm if any".
+
+import { test, expect } from '@playwright/test';
+import { suppressOneTimeModals } from './helpers/onetime';
+import { openEditor, gotoHome } from './helpers/hub';
+
+const selectAll = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
+
+// Deployed sites load third-party analytics/CDN scripts that throw uncaught errors
+// we don't own; treat those as noise (copied verbatim from smoke/library specs).
+const THIRD_PARTY_ERROR_SOURCES = [
+  'userscript.js',
+  'gtm.js',
+  'googletagmanager',
+  'google-analytics',
+  'analytics.js',
+  'clarity.js',
+  'clarity.ms',
+  'paddle.js',
+  'cdn.paddle.com',
+  'zaraz',
+  'cloudflareinsights',
+];
+
+function isThirdPartyError(err) {
+  const haystack = `${err?.message || ''}\n${err?.stack || ''}`;
+  return THIRD_PARTY_ERROR_SOURCES.some((src) => haystack.includes(src));
+}
+
+test.beforeEach(async ({ page }) => {
+  page.on('pageerror', (err) => {
+    if (isThirdPartyError(err)) return;
+    throw err;
+  });
+  // M04: seed onboarding/pledge flags before any navigation so their Radix overlays
+  // don't trap focus and intercept the header/card clicks these tests drive.
+  await suppressOneTimeModals(page);
+});
+
+// ── Local helpers (inlined; library.spec.js owns the shared copies — do not import
+//    from a sibling spec, and do NOT edit helpers/*.js which other agents touch). ──
+
+function editorLocator(page) {
+  return page.locator('[data-testid="dsl-editor"] .cm-content');
+}
+
+/** Navigate to the EDITOR with a clean localStorage slate. */
+async function gotoFresh(page) {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await openEditor(page);
+}
+
+/** Type a replacement DSL into the CM6 editor (select-all → Delete → type). */
+async function typeDsl(page, dsl, { timeout = 15_000 } = {}) {
+  const editor = editorLocator(page);
+  await expect(editor).toBeVisible({ timeout });
+  await editor.click();
+  await page.keyboard.press(selectAll);
+  await page.keyboard.press('Delete');
+  await editor.pressSequentially(dsl);
+}
+
+/** Set the diagram title via the header title field (used to identify rows). */
+async function setTitle(page, title) {
+  const titleInput = page.locator('[data-testid="header-title"]');
+  await expect(titleInput).toBeVisible();
+  await titleInput.click();
+  await page.keyboard.press(selectAll);
+  await page.keyboard.press('Delete');
+  await titleInput.pressSequentially(title);
+  await expect(titleInput).toHaveValue(title);
+}
+
+/**
+ * The FIRST signed-out Save opens a one-time "Saved on this device" notice (a Radix
+ * Dialog whose overlay intercepts the next click). Dismiss it via "Not now"
+ * (confirm-cancel). gotoFresh clears localStorage so the first save in every test
+ * shows it with certainty — await it deterministically when {expected:true}.
+ */
+async function dismissSaveNoticeIfPresent(page, { expected = false } = {}) {
+  const cancel = page.locator('[data-testid="confirm-cancel"]');
+  if (expected) {
+    await expect(cancel).toBeVisible();
+  } else if (!(await cancel.isVisible().catch(() => false))) {
+    return;
+  }
+  await cancel.click();
+  await expect(cancel).toBeHidden();
+}
+
+/** Seed one local item: set a distinctive title + DSL, then Save (header menu). */
+async function seedItem(page, { title, dsl, firstSave = false }) {
+  await setTitle(page, title);
+  await typeDsl(page, dsl);
+  await expect(editorLocator(page)).toContainText(dsl.split('\n')[0]);
+  await page.locator('[data-testid="header-menu"]').click();
+  await page.locator('[data-testid="header-save"]').click();
+  await dismissSaveNoticeIfPresent(page, { expected: firstSave });
+}
+
+/** Start a NEW blank diagram in the editor (header menu → New).
+ *
+ * Determinism guards (LIB-4 flake fix): a prior signed-out Save can leave the
+ * "Saved on this device" notice (a Radix Dialog with a fixed inset-0 overlay) on
+ * screen; its overlay intercepts the header-menu click and the whole open/click
+ * dance times out (~30s). So (1) first ensure that notice is fully dismissed and
+ * its overlay hidden, then (2) after opening the header menu, WAIT for the Radix
+ * dropdown's "New" item to actually be visible before clicking it — clicking
+ * header-new blindly races the dropdown's open animation. */
+async function newInEditor(page) {
+  // (1) Make sure no leftover "Saved on this device" notice overlay can swallow
+  // the menu click; wait for its cancel button (and thus the overlay) to be gone.
+  await dismissSaveNoticeIfPresent(page);
+  const saveNoticeCancel = page.locator('[data-testid="confirm-cancel"]');
+  await expect(saveNoticeCancel).toBeHidden();
+
+  // (2) Open the header menu and gate on the "New" item being visible before click.
+  await page.locator('[data-testid="header-menu"]').click();
+  const newItem = page.locator('[data-testid="header-new"]');
+  await expect(newItem).toBeVisible();
+  await newItem.click();
+  await expect(editorLocator(page)).toBeVisible();
+}
+
+/**
+ * Open a card's kebab menu and click an item by its visible text. The kebab trigger
+ * is opacity-0 until group-hover but is always in the DOM; hover first so it's
+ * interactable, then open via its aria-label and select the labelled MenuItem.
+ */
+async function openCardMenu(card, page, itemText) {
+  await card.hover();
+  await card.getByRole('button', { name: 'Diagram options' }).click();
+  // Radix DropdownMenu items render with role=menuitem in a portal.
+  await page.getByRole('menuitem', { name: itemText, exact: true }).click();
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// LIB-8: Empty hub shows the "No diagrams yet" empty state + both CTAs.
+// (Ordered first because it asserts on a clean slate with zero items.)
+// ──────────────────────────────────────────────────────────────────────────────
+test('LIB-8: empty hub shows "No diagrams yet" with New + Browse-templates CTAs', async ({
+  page,
+}) => {
+  // Clean localStorage → zero items → empty state. Go to the editor first only to
+  // clear storage from a same-origin page, then navigate to the hub.
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await gotoHome(page);
+
+  const empty = page.locator('[data-testid="home-empty"]');
+  await expect(empty).toBeVisible();
+  await expect(
+    empty.getByText('No diagrams yet', { exact: true }),
+  ).toBeVisible();
+
+  // Both first-run CTAs are present and labelled.
+  await expect(page.locator('[data-testid="home-empty-new"]')).toBeVisible();
+  await expect(
+    page.locator('[data-testid="home-empty-templates"]'),
+  ).toBeVisible();
+  await expect(page.locator('[data-testid="home-empty-new"]')).toHaveText(
+    'New diagram',
+  );
+  await expect(page.locator('[data-testid="home-empty-templates"]')).toHaveText(
+    'Browse templates',
+  );
+
+  // No grid renders while empty (proves the empty branch, not a hidden grid).
+  await expect(page.locator('[data-testid="home-grid"]')).toHaveCount(0);
+
+  // The empty-state New CTA actually opens the editor (blank diagram).
+  await page.locator('[data-testid="home-empty-new"]').click();
+  await expect(editorLocator(page)).toBeVisible({ timeout: 15_000 });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// LIB-6: The hub "New" CTA opens a blank editor.
+// ──────────────────────────────────────────────────────────────────────────────
+test('LIB-6: hub "New" CTA opens a blank editor', async ({ page }) => {
+  // Seed one item so the populated hub (with the split New button) renders — the
+  // empty state has its OWN New CTA (covered by LIB-8); this asserts the header one.
+  await gotoFresh(page);
+  await seedItem(page, {
+    title: 'SeedForNew',
+    dsl: 'NewA\nNewB\nNewA->NewB: seed',
+    firstSave: true,
+  });
+  await gotoHome(page);
+  await expect(page.locator('[data-testid="home-grid"]')).toBeVisible();
+
+  // Click the hub's primary New button → editor opens on a blank diagram.
+  await page.locator('[data-testid="home-new"]').click();
+  const editor = editorLocator(page);
+  await expect(editor).toBeVisible({ timeout: 15_000 });
+  // handleNewDiagramFromHome loads js:'' (blank) → the CM6 surface is empty.
+  await expect(editor).toHaveText('');
+  // The URL reflects the new diagram (?id=…) and is NOT the hub view.
+  await expect(page).toHaveURL(/[?&]id=/);
+  await expect(page.locator('[data-testid="home-view"]')).toHaveCount(0);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// LIB-5: A card shows DSL preview + title + last-updated date.
+// ──────────────────────────────────────────────────────────────────────────────
+test('LIB-5: a card shows DSL preview + title + last-updated', async ({
+  page,
+}) => {
+  await gotoFresh(page);
+
+  const title = 'PreviewCard';
+  const dsl =
+    'PreviewActor\nPreviewTarget\nPreviewActor->PreviewTarget: previewMessage';
+  await seedItem(page, { title, dsl, firstSave: true });
+
+  await gotoHome(page);
+  await expect(page.locator('[data-testid="home-grid"]')).toBeVisible();
+
+  // Locate this item's card (the only one in a fresh library).
+  const card = page.locator('[data-testid^="home-card-"]');
+  await expect(card).toHaveCount(1);
+
+  // Title is shown on the card.
+  await expect(card.getByText(title, { exact: true })).toBeVisible();
+
+  // DSL preview: the card renders a <pre> snippet of item.js — assert distinctive
+  // tokens from the seeded DSL appear in the card body (preview is whole-DSL,
+  // ≤240 chars; our DSL is well under that so the message line is included).
+  await expect(card).toContainText('PreviewActor');
+  await expect(card).toContainText('previewMessage');
+
+  // Last-updated: DiagramCard formats updatedOn as a localized short date via
+  // new Date(updatedOn).toLocaleDateString(undefined, {month:'short', day:'numeric'}).
+  // Compute the EXPECTED string INSIDE the browser (not in Node) so it uses the same
+  // runtime locale the component does — Node and Chromium default to different
+  // locales (Node here renders "18 June", Chromium "Jun 18"), which would make a
+  // Node-side toLocaleDateString a false mismatch. This stays a real assertion: it
+  // proves the card surfaces the seeded item's updatedOn as today's localized date.
+  const expectedDate = await page.evaluate(() =>
+    new Date().toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+    }),
+  );
+  await expect(card.getByText(expectedDate, { exact: true })).toBeVisible();
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// LIB-1: kebab → Duplicate yields a second "(Forked) …" card on the hub.
+// ──────────────────────────────────────────────────────────────────────────────
+test('LIB-1: card kebab Duplicate adds a second row', async ({ page }) => {
+  await gotoFresh(page);
+
+  const title = 'DupSource';
+  await seedItem(page, {
+    title,
+    dsl: 'DupA\nDupB\nDupA->DupB: original',
+    firstSave: true,
+  });
+
+  await gotoHome(page);
+  await expect(page.locator('[data-testid="home-grid"]')).toBeVisible();
+  await expect(page.locator('[data-testid^="home-card-"]')).toHaveCount(1);
+
+  // Open the card kebab → Duplicate. handleForkItem (AppRoot) forks the held item in
+  // the editor store — title → "(Forked) <title>", a NEW id, dirty:true — and calls
+  // setActivePanel('editor'). Crucially it does NOT navigate the URL, so the view is
+  // still governed by ?view=diagrams (isHomeMode stays true): we remain on the hub.
+  // The fork is unowned-until-saved, but autoSave defaults ON (settingsStore) and
+  // AppRoot's top-level useAutoSave persists any dirty item on its interval, which
+  // routes through itemService.setItem → localItems (a local write). useItems
+  // (signed-out) subscribes to localItems, so the new "(Forked) …" card appears in
+  // THIS hub grid in place — no remount, no editor visit. We assert that observable
+  // outcome with a generous poll covering the autosave interval.
+  const card = page.locator('[data-testid^="home-card-"]').first();
+  await openCardMenu(card, page, 'Duplicate');
+
+  // Still on the hub (Duplicate does not leave ?view=diagrams).
+  await expect(page.locator('[data-testid="home-view"]')).toBeVisible();
+
+  // The fork lands as a second card once autosave persists it (≤ autosave interval).
+  await expect(
+    page.getByText(`(Forked) ${title}`, { exact: true }),
+  ).toBeVisible({ timeout: 25_000 });
+  await expect(page.locator('[data-testid^="home-card-"]')).toHaveCount(2);
+  // The original survives alongside the fork.
+  await expect(page.getByText(title, { exact: true })).toBeVisible();
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// LIB-2: kebab → Delete removes the card (confirm if prompted).
+// ──────────────────────────────────────────────────────────────────────────────
+test('LIB-2: card kebab Delete removes the row', async ({ page }) => {
+  await gotoFresh(page);
+
+  // Seed TWO items so deleting one leaves a visible survivor (proves a targeted
+  // removal, not a wholesale clear).
+  await seedItem(page, {
+    title: 'DeleteMe',
+    dsl: 'DelA\nDelB\nDelA->DelB: gone',
+    firstSave: true,
+  });
+  await newInEditor(page);
+  await seedItem(page, {
+    title: 'KeepMe',
+    dsl: 'KeepA\nKeepB\nKeepA->KeepB: stays',
+  });
+
+  await gotoHome(page);
+  await expect(page.locator('[data-testid="home-grid"]')).toBeVisible();
+  await expect(page.locator('[data-testid^="home-card-"]')).toHaveCount(2);
+
+  // Open the DeleteMe card's kebab → Delete. The home card Delete runs
+  // itemService.removeItem immediately (no ConfirmDialog wraps it), but handle a
+  // confirm conditionally per the plan in case one is added later.
+  const deleteCard = page
+    .locator('[data-testid^="home-card-"]')
+    .filter({ hasText: 'DeleteMe' });
+  await expect(deleteCard).toHaveCount(1);
+  await openCardMenu(deleteCard, page, 'Delete');
+
+  // If a confirmation dialog appears, accept it (confirm-confirm); otherwise no-op.
+  const confirmBtn = page.locator('[data-testid="confirm-confirm"]');
+  if (await confirmBtn.isVisible().catch(() => false)) {
+    await confirmBtn.click();
+  }
+
+  // The DeleteMe card is gone; KeepMe survives; the grid shrinks to one card.
+  await expect(page.getByText('DeleteMe', { exact: true })).toHaveCount(0);
+  await expect(page.getByText('KeepMe', { exact: true })).toBeVisible();
+  await expect(page.locator('[data-testid^="home-card-"]')).toHaveCount(1);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// LIB-3: kebab → Export as HTML triggers a *.html download.
+// File downloads only work against a local build/dev server — self-skip on the
+// remote staging gate (same guard shape as production-build.spec.js).
+// ──────────────────────────────────────────────────────────────────────────────
+test('LIB-3: card kebab Export as HTML downloads a *.html file', async ({
+  page,
+}) => {
+  test.skip(
+    !!process.env.PW_BASE_URL,
+    'file-download assertion requires the local dev/build server',
+  );
+
+  await gotoFresh(page);
+  await seedItem(page, {
+    title: 'ExportHtmlCard',
+    dsl: 'HtmlA\nHtmlB\nHtmlA->HtmlB: exportHtml',
+    firstSave: true,
+  });
+
+  await gotoHome(page);
+  await expect(page.locator('[data-testid="home-grid"]')).toBeVisible();
+  const card = page.locator('[data-testid^="home-card-"]').first();
+
+  // handleExportHtml builds a standalone HTML doc and downloadText(`<safe>.html`, …);
+  // "ExportHtmlCard" → safe slug "exporthtmlcard.html". Assert the download fires
+  // with a *.html filename.
+  await card.hover();
+  await card.getByRole('button', { name: 'Diagram options' }).click();
+  const downloadPromise = page.waitForEvent('download', { timeout: 10_000 });
+  await page
+    .getByRole('menuitem', { name: 'Export as HTML', exact: true })
+    .click();
+  const download = await downloadPromise;
+
+  expect(download.suggestedFilename()).toMatch(/\.html$/);
+  expect(download.suggestedFilename()).toBe('exporthtmlcard.html');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// LIB-4: sort toggle Recent ↔ Title reorders the grid.
+// ──────────────────────────────────────────────────────────────────────────────
+test('LIB-4: sort toggle Recent ↔ Title reorders the grid', async ({
+  page,
+}) => {
+  await gotoFresh(page);
+
+  // Seed three items where save order (→ updatedOn) is the REVERSE of A–Z title
+  // order, so the two sorts produce visibly different sequences:
+  //   save order (newest first under "Recent"): Zeta, Mu, Alpha
+  //   title A–Z (under "Title"):                Alpha, Mu, Zeta
+  await seedItem(page, {
+    title: 'Alpha',
+    dsl: 'AlA\nAlB\nAlA->AlB: a',
+    firstSave: true,
+  });
+  await newInEditor(page);
+  await seedItem(page, { title: 'Mu', dsl: 'MuA\nMuB\nMuA->MuB: m' });
+  await newInEditor(page);
+  await seedItem(page, { title: 'Zeta', dsl: 'ZeA\nZeB\nZeA->ZeB: z' });
+
+  await gotoHome(page);
+  await expect(page.locator('[data-testid="home-grid"]')).toBeVisible();
+  await expect(page.locator('[data-testid^="home-card-"]')).toHaveCount(3);
+
+  // Read the on-card titles in DOM order. Each card's title is the first footer
+  // span; scope to the cards and map the visible title text.
+  async function cardTitlesInOrder() {
+    const cards = page.locator('[data-testid^="home-card-"]');
+    const n = await cards.count();
+    const titles = [];
+    for (let i = 0; i < n; i++) {
+      // The card's accessible "Open <title>" button label carries the exact title;
+      // read it to avoid coupling to the preview/date spans.
+      const label = await cards
+        .nth(i)
+        .getByRole('button', { name: /^Open / })
+        .getAttribute('aria-label');
+      titles.push(label.replace(/^Open /, ''));
+    }
+    return titles;
+  }
+
+  // Default sort is "Recent" (updated desc) → newest save first.
+  expect(await cardTitlesInOrder()).toEqual(['Zeta', 'Mu', 'Alpha']);
+
+  // Toggle the sort Select to "Title" → alphabetical A–Z.
+  await page.locator('[data-testid="home-sort"]').click();
+  await page.getByRole('option', { name: 'Title', exact: true }).click();
+  await expect
+    .poll(async () => await cardTitlesInOrder())
+    .toEqual(['Alpha', 'Mu', 'Zeta']);
+
+  // Toggle back to "Recent" → the updated-desc order returns (proves it's a real
+  // re-sort, not a one-way change).
+  await page.locator('[data-testid="home-sort"]').click();
+  await page.getByRole('option', { name: 'Recent', exact: true }).click();
+  await expect
+    .poll(async () => await cardTitlesInOrder())
+    .toEqual(['Zeta', 'Mu', 'Alpha']);
+});

--- a/e2e/tests/mobile.spec.js
+++ b/e2e/tests/mobile.spec.js
@@ -1,0 +1,296 @@
+// Mobile / responsive E2E (signed-out / local flows only).
+//
+// The rewrite renders a DIFFERENT layout below the Tailwind `md` breakpoint
+// (web/src/hooks/useMediaQuery.ts → useIsMobile = max-width:767px):
+//   - Layout.tsx drops split.js and shows a single pane with a segmented
+//     Edit | Preview control (layout-tab-edit / layout-tab-preview); the inactive
+//     pane (editor-region / preview-region) is hidden via Tailwind `hidden`.
+//   - AppRoot passes svgMode={isMobile && !fullscreen} to PreviewFrame, so the
+//     mobile non-fullscreen preview renders @zenuml/core's NATIVE vector SVG into
+//     a #svg-mount container (fit-to-width, width:100%) instead of the fixed-px
+//     HTML diagram in #mounting-point (which overflows a phone viewport).
+//   - The header action buttons (Share / Present) collapse to icon-only below md:
+//     their label <span class="hidden md:inline"> is display:none while the glyph
+//     and aria-label persist (ShareButton.tsx / AppHeader.tsx).
+//   - The DialogContent shell + Settings modal cap height at the viewport
+//     (max-h-85vh + an inner overflow-y-auto scroll surface), so a tall modal
+//     stays contained on a small screen.
+//
+// Covers the gap-plan MOBILE cases: PRV-5, MOB-1, MOB-3, MOB-4. Pure browser /
+// no backend — runs in the staging gate signed-out. We force a phone viewport
+// (~390x844) with page.setViewportSize so useIsMobile resolves true.
+
+import { test, expect } from '@playwright/test';
+import { suppressOneTimeModals } from './helpers/onetime';
+import { openEditor } from './helpers/hub';
+
+// Deployed sites (staging/prod via PW_BASE_URL) load third-party analytics/CDN
+// scripts that throw uncaught errors we don't own; treat those as noise. Genuine
+// app errors still fail the test. (Copied verbatim from smoke.spec.js.)
+const THIRD_PARTY_ERROR_SOURCES = [
+  'userscript.js',
+  'gtm.js',
+  'googletagmanager',
+  'google-analytics',
+  'analytics.js',
+  'clarity.js',
+  'clarity.ms',
+  'paddle.js',
+  'cdn.paddle.com',
+  'zaraz',
+  'cloudflareinsights',
+];
+
+function isThirdPartyError(err) {
+  const haystack = `${err?.message || ''}\n${err?.stack || ''}`;
+  return THIRD_PARTY_ERROR_SOURCES.some((src) => haystack.includes(src));
+}
+
+// Phone portrait — below the md (767px) breakpoint so useIsMobile() resolves true.
+const PHONE = { width: 390, height: 844 };
+
+const selectAll = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
+
+const EDITOR_SURFACE = '[data-testid="dsl-editor"] .cm-content';
+
+/**
+ * Set the phone viewport BEFORE the first navigation, suppress the one-time
+ * modals, then land on the editor. Setting the viewport first means useIsMobile()
+ * reads `matches: true` on its initial render — the layout boots mobile, with no
+ * desktop→mobile re-layout flash to race.
+ */
+async function gotoEditorMobile(page) {
+  await page.setViewportSize(PHONE);
+  await suppressOneTimeModals(page);
+  await openEditor(page);
+}
+
+/** Type a replacement DSL into the CM6 editor (select-all → Delete → type). */
+async function typeDsl(page, dsl, { timeout = 15_000 } = {}) {
+  const editor = page.locator(EDITOR_SURFACE);
+  await expect(editor).toBeVisible({ timeout });
+  await editor.click();
+  await page.keyboard.press(selectAll);
+  await page.keyboard.press('Delete');
+  await editor.pressSequentially(dsl);
+}
+
+test.beforeEach(async ({ page }) => {
+  page.on('pageerror', (err) => {
+    if (isThirdPartyError(err)) return;
+    throw err;
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// MOB-1: the segmented control toggles Editor ↔ Preview panes.
+// ──────────────────────────────────────────────────────────────────────────────
+test('MOB-1: the segmented control toggles between the Editor and Preview panes', async ({
+  page,
+}) => {
+  await gotoEditorMobile(page);
+
+  const editTab = page.locator('[data-testid="layout-tab-edit"]');
+  const previewTab = page.locator('[data-testid="layout-tab-preview"]');
+  const editorRegion = page.locator('[data-testid="editor-region"]');
+  const previewRegion = page.locator('[data-testid="preview-region"]');
+
+  // The segmented control exists ONLY in the mobile single-pane layout — its
+  // presence proves we booted the mobile layout (desktop has no such tabs).
+  await expect(editTab).toBeVisible();
+  await expect(previewTab).toBeVisible();
+
+  // Default tab is Edit: the editor pane is shown, the preview pane is hidden
+  // (Layout applies Tailwind `hidden` → display:none on the inactive pane, which
+  // Playwright treats as not visible).
+  await expect(editTab).toHaveAttribute('aria-pressed', 'true');
+  await expect(previewTab).toHaveAttribute('aria-pressed', 'false');
+  await expect(editorRegion).toBeVisible();
+  await expect(previewRegion).toBeHidden();
+  // The CM6 editing surface lives inside the visible editor pane.
+  await expect(page.locator(EDITOR_SURFACE)).toBeVisible();
+
+  // Switch to Preview: the panes swap visibility and the pressed state flips.
+  await previewTab.click();
+  await expect(previewTab).toHaveAttribute('aria-pressed', 'true');
+  await expect(editTab).toHaveAttribute('aria-pressed', 'false');
+  await expect(previewRegion).toBeVisible();
+  await expect(editorRegion).toBeHidden();
+  // The preview iframe is in the now-visible preview pane.
+  await expect(page.locator('[data-testid="preview-iframe"]')).toBeVisible();
+  // The editor surface is in the hidden pane, so it is not visible now.
+  await expect(page.locator(EDITOR_SURFACE)).toBeHidden();
+
+  // Switch back to Edit: visibility returns to the initial state (toggle is reversible).
+  await editTab.click();
+  await expect(editTab).toHaveAttribute('aria-pressed', 'true');
+  await expect(editorRegion).toBeVisible();
+  await expect(previewRegion).toBeHidden();
+  await expect(page.locator(EDITOR_SURFACE)).toBeVisible();
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PRV-5: mobile non-fullscreen preview renders the NATIVE vector SVG (fit-to-width)
+// into #svg-mount, NOT the fixed-px HTML diagram in #mounting-point.
+//
+// Local-build only: the SVG render path runs @zenuml/core's renderToSvg INSIDE the
+// srcdoc iframe and asserts on injected DOM in that iframe. That requires the live
+// bundle + cross-frame DOM access — both available against the local dev/preview
+// server but not guaranteed (or worth the flake) against a remote staging origin.
+// ──────────────────────────────────────────────────────────────────────────────
+test('PRV-5: mobile non-fullscreen preview renders native SVG (fit-to-width), not fixed-px HTML', async ({
+  page,
+}) => {
+  test.skip(
+    !!process.env.PW_BASE_URL,
+    'PRV-5 inspects @zenuml/core renderToSvg output inside the srcdoc iframe — local build only',
+  );
+
+  await gotoEditorMobile(page);
+
+  // Drive a distinctive diagram so the render is deterministic, then switch to the
+  // Preview pane (mobile single-pane: the preview must be the active tab to view it).
+  await typeDsl(page, 'MobAlice\nMobBob\nMobAlice->MobBob: SvgRenderTest');
+  await page.locator('[data-testid="layout-tab-preview"]').click();
+
+  const frame = page.frameLocator('[data-testid="preview-iframe"]');
+
+  // The native SVG lands inside the dynamically-created #svg-mount container
+  // (bootstrap showSvgMount), as a real <svg> element. Target the DIRECT child
+  // root <svg> — `#svg-mount svg` (descendant) also matches the nested inner
+  // <svg> arrow-heads @zenuml/core emits, tripping Playwright strict mode
+  // non-deterministically as the inner SVGs commit. `> svg` is exactly the
+  // top-level injected root the bootstrap sizes to width:100%.
+  const svg = frame.locator('#svg-mount > svg');
+  await expect(svg).toBeVisible({ timeout: 20_000 });
+
+  // Fit-to-width: the bootstrap strips the intrinsic width/height attrs and sets
+  // style width:100% so the viewBox drives the aspect ratio. Assert both the inline
+  // style and the COMPUTED width that fills the iframe's content box (no fixed px).
+  await expect(svg).toHaveAttribute('style', /width:\s*100%/);
+  const widthMatchesContainer = await svg.evaluate((el) => {
+    const svgW = el.getBoundingClientRect().width;
+    const parentW = el.parentElement
+      ? el.parentElement.getBoundingClientRect().width
+      : 0;
+    // Fit-to-width: the SVG spans essentially the full width of its #svg-mount
+    // parent (allow a small rounding/scrollbar slack), proving it is not a
+    // fixed-px HTML layout narrower/wider than the phone viewport.
+    return parentW > 0 && Math.abs(svgW - parentW) <= 2;
+  });
+  expect(widthMatchesContainer).toBe(true);
+
+  // The fixed-px HTML diagram mount (#mounting-point) is HIDDEN in SVG mode
+  // (showSvgMount sets it display:none) — proving HTML layout is not the surface.
+  const htmlMountDisplay = await frame
+    .locator('#mounting-point')
+    .evaluate((el) => getComputedStyle(el).display);
+  expect(htmlMountDisplay).toBe('none');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// MOB-3: action buttons (Share / Present) are icon-only on mobile (label hidden).
+// ──────────────────────────────────────────────────────────────────────────────
+test('MOB-3: Share and Present action buttons are icon-only on mobile (text label hidden)', async ({
+  page,
+}) => {
+  await gotoEditorMobile(page);
+
+  // Both action buttons render their glyph + a label <span class="hidden md:inline">.
+  // Below md the label is display:none; the button itself stays visible and keeps
+  // its accessible name via aria-label.
+  const shareBtn = page.locator('[data-testid="share-button"]');
+  const presentBtn = page.locator('[data-testid="header-present"]');
+  await expect(shareBtn).toBeVisible();
+  await expect(presentBtn).toBeVisible();
+
+  // The accessible name persists even though the visible text is hidden.
+  await expect(shareBtn).toHaveAttribute('aria-label', 'Share');
+  await expect(presentBtn).toHaveAttribute('aria-label', 'Present');
+
+  // Icon-only: the "Share"/"Present" label span carries `hidden md:inline`, which
+  // is display:none at this width. Playwright's text query only returns VISIBLE
+  // text, so the visible text inside each button is empty on mobile.
+  await expect(shareBtn.locator('span.hidden.md\\:inline')).toBeHidden();
+  await expect(presentBtn.locator('span.hidden.md\\:inline')).toBeHidden();
+  // The visible-text accessor returns '' because only the hidden label carries text.
+  expect((await shareBtn.innerText()).trim()).toBe('');
+  expect((await presentBtn.innerText()).trim()).toBe('');
+
+  // The decorative glyph (an <svg>) IS rendered inside each button — icon-only,
+  // not a blank control.
+  await expect(shareBtn.locator('svg').first()).toBeVisible();
+  await expect(presentBtn.locator('svg').first()).toBeVisible();
+
+  // Cross-check the same labels DO show at desktop width — proves the hiding is a
+  // responsive (md+) behavior, not that the label is always absent.
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await expect(presentBtn.locator('span.hidden.md\\:inline')).toBeVisible();
+  await expect(presentBtn).toContainText('Present');
+  await expect(shareBtn.locator('span.hidden.md\\:inline')).toBeVisible();
+  await expect(shareBtn).toContainText('Share');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// MOB-4: a tall modal fits the phone viewport and scrolls (no overflow past it).
+//
+// The Settings modal is the tallest (18 control rows). Its DialogContent caps at
+// max-h-85vh + overflow-hidden, and an inner settings-scroll surface is
+// overflow-y-auto — so on a short phone the modal's box stays within the viewport
+// and the rows scroll inside it (rather than the modal growing past the screen).
+// ──────────────────────────────────────────────────────────────────────────────
+test('MOB-4: a tall modal fits the viewport and scrolls internally on mobile', async ({
+  page,
+}) => {
+  await gotoEditorMobile(page);
+
+  // Open Settings via the header overflow menu (same path as modals.spec.js).
+  await page.locator('[data-testid="header-menu"]').click();
+  await page.locator('[data-testid="header-settings"]').click();
+
+  await expect(page.locator('[data-testid="settings-modal"]')).toBeVisible();
+
+  // The VISIBLE modal box is the Radix DialogContent ([role="dialog"]), which is
+  // capped at max-h-85vh + overflow-hidden — that capped box is what must fit the
+  // screen. (The settings-modal testid is the UNBOUNDED inner content wrapper that
+  // the scroll surface clips; measuring it would wrongly report the full row stack.)
+  const modal = page.getByRole('dialog');
+  await expect(modal).toBeVisible();
+  const box = await modal.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box.y).toBeGreaterThanOrEqual(-1); // top is on-screen (small AA slack)
+  // Bottom does not run past the viewport — the modal is contained (85vh of 844 ≈
+  // 718px tall, centered → bottom well within 844). A naive uncapped modal would
+  // overflow here, which is exactly what this case guards against.
+  expect(box.y + box.height).toBeLessThanOrEqual(PHONE.height + 1);
+  // And it IS shorter than the viewport (the cap actually took effect on a phone).
+  expect(box.height).toBeLessThan(PHONE.height);
+
+  // The inner rows are the scroll surface: settings-scroll is overflow-y-auto and
+  // its content overflows its capped height on a short phone, so it is scrollable.
+  const scroll = page.locator('[data-testid="settings-scroll"]');
+  await expect(scroll).toBeVisible();
+
+  const metrics = await scroll.evaluate((el) => ({
+    scrollHeight: el.scrollHeight,
+    clientHeight: el.clientHeight,
+    overflowY: getComputedStyle(el).overflowY,
+  }));
+  // The scroll container is the overflow owner and its content is taller than its
+  // visible box — i.e. there ARE rows below the fold to scroll to.
+  expect(metrics.overflowY).toBe('auto');
+  expect(metrics.scrollHeight).toBeGreaterThan(metrics.clientHeight);
+
+  // Actually scroll it and assert scrollTop advances — the rows move INSIDE the
+  // modal (the modal box itself is fixed), confirming internal scroll, not overflow.
+  const scrolledTo = await scroll.evaluate((el) => {
+    el.scrollTop = el.scrollHeight; // scroll to the bottom
+    return el.scrollTop;
+  });
+  expect(scrolledTo).toBeGreaterThan(0);
+
+  // After scrolling the rows, the modal box is STILL within the viewport (the
+  // overflow was absorbed internally, not by the modal growing off-screen).
+  const boxAfter = await modal.boundingBox();
+  expect(boxAfter.y + boxAfter.height).toBeLessThanOrEqual(PHONE.height + 1);
+});

--- a/e2e/tests/modals-gap.spec.js
+++ b/e2e/tests/modals-gap.spec.js
@@ -1,0 +1,323 @@
+// Modals — uncovered/deeper coverage (E2E_GAP_TEST_PLAN §"Modals").
+//
+// modals.spec.js already covers OPEN + one action + Escape for Settings /
+// Create-New / Help / Cheat-Sheet / Shortcuts / Pricing. This spec does NOT
+// duplicate those; it covers the deeper modal behaviours the gap plan calls out:
+//   MOD-1 onboarding shows once per profile (localStorage `onboarded`)
+//   MOD-3 single-modal invariant (open Settings → open Help → Settings is gone)
+//   MOD-4 Help links have correct hrefs + target=_blank + rel=noopener
+//   MOD-5 cheat-sheet lists the documented example rows
+//   MOD-6 shortcuts modal lists the Global + Editor groups
+//   MOD-7 login modal opens from header "Sign in" AND from a gated action
+//
+// Selectors are taken from the components verbatim (AppMenu.tsx / HelpModal.tsx /
+// CheatSheetModal.tsx / KeyboardShortcutsModal.tsx / OnboardingModal.tsx /
+// AppHeader.tsx / CssPanel.tsx / AppRoot.tsx) — none invented.
+//
+// Onboarding gate (AppRoot.tsx): the first-run effect opens onboarding only when
+// localStorage `onboarded` is falsy AND syncStore `lastSeenVersion` is empty. On
+// web, syncStore falls back to localStorage, so a clean localStorage slate (no
+// suppressOneTimeModals) is the genuine first-run condition. MOD-1 deliberately
+// does NOT call suppressOneTimeModals — it needs the real first-run path. Every
+// other test here DOES suppress so onboarding/pledge don't trap focus.
+
+import { test, expect } from '@playwright/test';
+import { suppressOneTimeModals } from './helpers/onetime';
+import { openEditor } from './helpers/hub';
+
+// Deployed sites (staging/prod via PW_BASE_URL) load third-party analytics/CDN
+// scripts that throw uncaught errors we don't own; treat those as noise. Copied
+// verbatim from smoke.spec.js so this spec stays usable on the staging gate.
+const THIRD_PARTY_ERROR_SOURCES = [
+  'userscript.js',
+  'gtm.js',
+  'googletagmanager',
+  'google-analytics',
+  'analytics.js',
+  'clarity.js',
+  'clarity.ms',
+  'paddle.js',
+  'cdn.paddle.com',
+  'zaraz',
+  'cloudflareinsights',
+];
+
+function isThirdPartyError(err) {
+  const haystack = `${err?.message || ''}\n${err?.stack || ''}`;
+  return THIRD_PARTY_ERROR_SOURCES.some((src) => haystack.includes(src));
+}
+
+test.beforeEach(async ({ page }) => {
+  // Fail on genuine uncaught app errors; ignore known third-party noise.
+  page.on('pageerror', (err) => {
+    if (isThirdPartyError(err)) return;
+    throw err;
+  });
+});
+
+/** Open an item in the header app-menu by its trigger testid. */
+async function openViaHeaderMenu(page, triggerTestId) {
+  await page.locator('[data-testid="header-menu"]').click();
+  await page.locator(`[data-testid="${triggerTestId}"]`).click();
+}
+
+/** Reach the editor with a clean localStorage slate AND one-time modals suppressed. */
+async function gotoEditorSuppressed(page) {
+  await suppressOneTimeModals(page);
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await openEditor(page);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// MOD-1: Onboarding modal shows once per profile (localStorage `onboarded`).
+// fresh slate → onboarding shown; dismiss stamps `onboarded` (+ lastSeenVersion);
+// a reload of the SAME profile → onboarding gone.
+// ──────────────────────────────────────────────────────────────────────────────
+test('MOD-1: onboarding modal shows on first run and is gone after dismiss + reload', async ({
+  page,
+}) => {
+  test.skip(
+    !!process.env.PW_BASE_URL,
+    'needs a local clean-slate (empty onboarded/lastSeenVersion); flaky on the deployed staging gate',
+  );
+  // First-run path — do NOT suppress the one-time modals; we WANT onboarding.
+  // Land on the origin, wipe storage to simulate a brand-new profile, then reload
+  // so AppRoot's boot effect re-evaluates the (now empty) onboarding gate.
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+
+  // Bare '/' boots the editor; the onboarding effect opens its modal on the empty
+  // `onboarded` + empty `lastSeenVersion` slate.
+  const onboarding = page.locator('[data-testid="onboarding-modal"]');
+  await expect(onboarding).toBeVisible({ timeout: 15_000 });
+
+  // Sanity: the dismiss flag is not yet set before we dismiss.
+  expect(
+    await page.evaluate(() => localStorage.getItem('onboarded')),
+  ).toBeNull();
+
+  // Dismiss via "Get started" → AppRoot's onDismiss writes localStorage.onboarded
+  // = true and closes the modal.
+  await page.locator('[data-testid="onboarding-get-started"]').click();
+  await expect(onboarding).toBeHidden();
+
+  // The dismissal persisted the `onboarded` flag for this profile.
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem('onboarded')))
+    .toBe('true');
+
+  // Reload the SAME profile (no storage clear): onboarding must NOT reappear.
+  await page.reload();
+  await expect(page.locator('[data-testid="dsl-editor"]')).toBeVisible({
+    timeout: 15_000,
+  });
+  // Give the boot effects a beat, then assert onboarding stayed closed.
+  await expect(page.locator('[data-testid="onboarding-modal"]')).toHaveCount(0);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// MOD-3: only one modal open at a time. Opening a second modal while one is open
+// replaces it (activeModal is a single value in uiStore) — the first closes.
+//
+// We open the SECOND modal via the global Ctrl/Cmd+Shift+? shortcut rather than
+// the header menu: the first modal's Radix overlay (fixed inset-0) intercepts
+// pointer events on the header trigger, but the shortcut is a window keydown
+// listener (AppRoot) that fires regardless of the overlay — and routes through the
+// same openModal('shortcuts') the menu would, so it exercises the same invariant.
+// ──────────────────────────────────────────────────────────────────────────────
+test('MOD-3: opening a second modal closes the first (single-modal invariant)', async ({
+  page,
+}) => {
+  await gotoEditorSuppressed(page);
+
+  // Open Settings via the header menu.
+  await openViaHeaderMenu(page, 'header-settings');
+  const settings = page.locator('[data-testid="settings-modal"]');
+  await expect(settings).toBeVisible();
+
+  // Open the Keyboard-Shortcuts modal via the global accelerator while Settings is
+  // open. activeModal is single-valued, so this must REPLACE Settings.
+  const mod = process.platform === 'darwin' ? 'Meta' : 'Control';
+  await page.keyboard.press(`${mod}+Shift+?`);
+
+  const shortcuts = page.locator('[data-testid="shortcuts-modal"]');
+  await expect(shortcuts).toBeVisible();
+
+  // The invariant: Settings is gone, exactly one modal (Shortcuts) is open.
+  await expect(settings).toHaveCount(0);
+  await expect(shortcuts).toBeVisible();
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// MOD-4: Help modal links (Docs / Contact / GitHub) have the correct hrefs and
+// open safely in a new tab (target=_blank + rel includes noopener).
+// ──────────────────────────────────────────────────────────────────────────────
+test('MOD-4: Help modal links carry correct hrefs + target=_blank + rel=noopener', async ({
+  page,
+}) => {
+  await gotoEditorSuppressed(page);
+  await openViaHeaderMenu(page, 'header-help');
+
+  const modal = page.locator('[data-testid="help-modal"]');
+  await expect(modal).toBeVisible();
+
+  // Exact URLs sourced from HelpModal.tsx (DOCS_URL / CONTACT_URL / GITHUB_URL).
+  const links = [
+    { name: 'Documentation & help', href: 'https://www.zenuml.com/help.html' },
+    { name: 'Contact us', href: 'https://zenuml.com/docs/about/contact-us' },
+    { name: 'GitHub', href: 'https://github.com/ZenUml/web-sequence' },
+  ];
+
+  for (const { name, href } of links) {
+    const link = modal.getByRole('link', { name });
+    await expect(link).toHaveAttribute('href', href);
+    await expect(link).toHaveAttribute('target', '_blank');
+    // rel is "noreferrer noopener" — assert it contains noopener (the security bit).
+    await expect(link).toHaveAttribute('rel', /noopener/);
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// MOD-5: cheat-sheet lists the documented example rows. Assert the feature labels
+// AND their example DSL (the rows are SOURCED in CheatSheetModal.tsx, not invented).
+// ──────────────────────────────────────────────────────────────────────────────
+test('MOD-5: cheat-sheet lists the documented DSL example rows', async ({
+  page,
+}) => {
+  await gotoEditorSuppressed(page);
+  await openViaHeaderMenu(page, 'header-cheatsheet');
+
+  const modal = page.locator('[data-testid="cheatsheet-modal"]');
+  await expect(modal).toBeVisible();
+
+  // Feature labels every documented row carries (CheatSheetModal.tsx ROWS).
+  for (const feature of [
+    'Participant',
+    'Message',
+    'Async message',
+    'Nested message',
+    'Self-message',
+    'Return',
+    'Instance creation',
+    'Alt (conditional)',
+    'Loop',
+    'Comment',
+  ]) {
+    await expect(modal.getByText(feature, { exact: true })).toBeVisible();
+  }
+
+  // And the example DSL for a few rows, proving the EXAMPLE column rendered too.
+  await expect(modal).toContainText('Alice->Bob: How are you?'); // async message
+  await expect(modal).toContainText('a = new A()'); // instance creation
+  await expect(modal).toContainText('while (condition)'); // loop
+  await expect(modal).toContainText('// This is a comment'); // comment
+
+  // Count the rendered rows — one <tr> per documented feature (10).
+  await expect(modal.locator('tbody tr')).toHaveCount(10);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// MOD-6: shortcuts modal lists the Global + Editor groups, with representative
+// bindings under each (KeyboardShortcutsModal.tsx GLOBAL / EDITOR sections).
+// ──────────────────────────────────────────────────────────────────────────────
+test('MOD-6: shortcuts modal lists the Global and Editor groups with bindings', async ({
+  page,
+}) => {
+  await gotoEditorSuppressed(page);
+  await openViaHeaderMenu(page, 'header-shortcuts');
+
+  const modal = page.locator('[data-testid="shortcuts-modal"]');
+  await expect(modal).toBeVisible();
+
+  // Both group headers render.
+  await expect(modal.getByRole('heading', { name: 'Global' })).toBeVisible();
+  await expect(modal.getByRole('heading', { name: 'Editor' })).toBeVisible();
+
+  // Representative GLOBAL bindings.
+  await expect(modal.getByText('Save', { exact: true })).toBeVisible();
+  await expect(modal.getByText('Clear console', { exact: true })).toBeVisible();
+  await expect(
+    modal.getByText('Keyboard-shortcuts help', { exact: true }),
+  ).toBeVisible();
+  await expect(modal).toContainText('Ctrl/Cmd+S'); // Save binding text
+
+  // Representative EDITOR bindings.
+  await expect(modal.getByText('Find', { exact: true })).toBeVisible();
+  await expect(
+    modal.getByText('Toggle comment', { exact: true }),
+  ).toBeVisible();
+  await expect(modal).toContainText('Ctrl/Cmd+/'); // toggle-comment binding text
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// MOD-7a: login modal opens from the header "Sign in" button (signed-out editor).
+// ──────────────────────────────────────────────────────────────────────────────
+test('MOD-7: login modal opens from the header "Sign in" affordance', async ({
+  page,
+}) => {
+  test.skip(
+    !!process.env.PW_BASE_URL,
+    'needs a signed-out slate (header "Sign in" only renders when logged out); flaky on the deployed staging gate',
+  );
+  await gotoEditorSuppressed(page);
+
+  // Signed-out → the header shows the "Sign in" button (header-login).
+  const signIn = page.locator('[data-testid="header-login"]');
+  await expect(signIn).toBeVisible();
+  await signIn.click();
+
+  // LoginModal opens. It has no inner wrapper testid; its provider buttons do
+  // (login-<provider>), and they only exist inside the open modal — anchor on
+  // them. All four providers (google/github/facebook/twitter) render.
+  for (const provider of ['google', 'github', 'facebook', 'twitter']) {
+    await expect(
+      page.locator(`[data-testid="login-${provider}"]`),
+    ).toBeVisible();
+  }
+  // The modal carries its accessible title.
+  await expect(
+    page.getByRole('dialog').getByText('Sign in to ZenUML'),
+  ).toBeVisible();
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// MOD-7b: login modal opens from a GATED action. Custom (non-plain) CSS is
+// Plus-only; for a signed-out user, switching the CSS mode to SCSS routes through
+// cssGated() which opens the sign-in modal (AppRoot.handleSetCssMode → cssGated →
+// setLoginModalOpen(true)).
+// ──────────────────────────────────────────────────────────────────────────────
+test('MOD-7: a gated custom-CSS action opens the login modal (signed-out)', async ({
+  page,
+}) => {
+  test.skip(
+    !!process.env.PW_BASE_URL,
+    'needs a signed-out slate (the CSS gate only opens login when logged out); flaky on the deployed staging gate',
+  );
+  await gotoEditorSuppressed(page);
+
+  // The CSS panel is collapsed by default (empty CSS) — expand it to reach the
+  // pre-processor mode Select (CssPanel: css-panel-strip → css-panel-expanded).
+  await page.locator('[data-testid="css-panel-strip"]').click();
+  const modeSelect = page.locator('[data-testid="css-mode-select"]');
+  await expect(modeSelect).toBeVisible();
+
+  // No login modal yet.
+  await expect(page.locator('[data-testid="login-google"]')).toHaveCount(0);
+
+  // Pick SCSS (a non-plain mode) → cssGated() opens sign-in for the anonymous user.
+  await modeSelect.click();
+  await page.getByRole('option', { name: 'SCSS', exact: true }).click();
+
+  // The login modal opened — its provider buttons (only present when open) appear.
+  await expect(page.locator('[data-testid="login-google"]')).toBeVisible();
+  await expect(
+    page.getByRole('dialog').getByText('Sign in to ZenUML'),
+  ).toBeVisible();
+
+  // Gate held: because the mode change was withheld (cssGated returned true), the
+  // mode select did NOT switch to SCSS — it still reads the plain CSS mode.
+  await expect(modeSelect).toContainText('CSS');
+  await expect(modeSelect).not.toContainText('SCSS');
+});

--- a/e2e/tests/multipage.spec.js
+++ b/e2e/tests/multipage.spec.js
@@ -1,0 +1,251 @@
+// Multi-page (PG-1..PG-4) — signed-out / local UI, no Firebase emulator.
+//
+// Drives the PageTabs component (web/src/components/pages/PageTabs.tsx), which
+// renders inside the renderer header, always present in the editor. REAL
+// selectors from that component:
+//   - page-tab-<id>      : a <div role="tab"> per page; double-click → rename
+//   - page-rename-<id>   : the inline TextInput shown while renaming a tab
+//   - page-delete-<id>   : the × IconButton, ONLY rendered when !page.isDefault
+//   - page-add           : the + IconButton (addPage auto-switches to the new page)
+//   - confirm-ok / confirm-cancel : the shared ConfirmDialog buttons (delete confirm)
+//
+// Page ids are genId()-dynamic, so each test discovers the live id from the
+// `page-tab-<id>` testid rather than hard-coding one — mirroring persistence.spec.js's
+// positional `[data-testid^="page-tab-"]` approach.
+//
+// PG-4 note: signed-out, the header save-state indicator is pinned to "local"
+// (AppHeader SaveState short-circuits `!signedIn → local` BEFORE the dirty branch),
+// so it is NOT a usable dirty signal here. The renamePage store action sets
+// dirty=true (editorStore.ts:76) which is what gates persistence; the observable
+// proof is that a manual Save (which only writes because the item is dirty) persists
+// the renamed page title into the item's localStorage record (itemService.setItem →
+// localStore.set(id, item) → localStorage[<id>] = JSON with pages[].title).
+
+import { test, expect } from '@playwright/test';
+import { suppressOneTimeModals } from './helpers/onetime';
+import { openEditor } from './helpers/hub';
+
+// Deployed sites (staging/prod via PW_BASE_URL) load third-party analytics/CDN
+// scripts that throw uncaught errors we don't own; treat those as noise so this
+// spec stays usable against the live staging E2E gate. Locally there are none.
+const THIRD_PARTY_ERROR_SOURCES = [
+  'userscript.js',
+  'gtm.js',
+  'googletagmanager',
+  'google-analytics',
+  'analytics.js',
+  'clarity.js',
+  'clarity.ms',
+  'paddle.js',
+  'cdn.paddle.com',
+  'zaraz',
+  'cloudflareinsights',
+];
+function isThirdPartyError(err) {
+  const haystack = `${err?.message || ''}\n${err?.stack || ''}`;
+  return THIRD_PARTY_ERROR_SOURCES.some((src) => haystack.includes(src));
+}
+
+/**
+ * Navigate to the EDITOR with a clean localStorage slate.
+ * Land on the origin to clear storage, then click through the hub (openEditor) so
+ * boot seeds a fresh sample item — its single default page is what PG-3 checks.
+ */
+async function gotoFresh(page) {
+  await suppressOneTimeModals(page); // M04: keep onboarding/pledge from trapping focus
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await openEditor(page);
+  // The PageTabs live in the renderer header — at least the default tab is present.
+  await expect(page.locator('[data-testid^="page-tab-"]').first()).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+/** Extract the genId() page id from a `page-tab-<id>` element's testid. */
+async function pageIdOf(tab) {
+  const testid = await tab.getAttribute('data-testid');
+  return testid.replace('page-tab-', '');
+}
+
+test.beforeEach(async ({ page }) => {
+  page.on('pageerror', (err) => {
+    if (!isThirdPartyError(err)) throw err;
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PG-1: Rename a page inline (double-click tab) — the tab label updates.
+// ──────────────────────────────────────────────────────────────────────────────
+test('PG-1: double-click a page tab, rename it, and the tab label updates', async ({
+  page,
+}) => {
+  await gotoFresh(page);
+
+  const firstTab = page.locator('[data-testid^="page-tab-"]').first();
+  const id = await pageIdOf(firstTab);
+
+  // Default page starts as "Page 1".
+  await expect(firstTab).toContainText('Page 1');
+
+  // Enter rename mode via double-click → the inline TextInput appears.
+  await firstTab.dblclick();
+  const renameInput = page.locator(`[data-testid="page-rename-${id}"]`);
+  await expect(renameInput).toBeVisible();
+
+  // Replace the title and commit with Enter (commitRename → onRename).
+  const NEW_TITLE = 'Login Flow';
+  await renameInput.fill(NEW_TITLE);
+  await renameInput.press('Enter');
+
+  // The rename input is gone and the SAME tab (same id) now shows the new label.
+  await expect(renameInput).toBeHidden();
+  const renamedTab = page.locator(`[data-testid="page-tab-${id}"]`);
+  await expect(renamedTab).toContainText(NEW_TITLE);
+  await expect(renamedTab).not.toContainText('Page 1');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PG-2: Delete a non-default page (confirm dialog) removes it; active falls back.
+// ──────────────────────────────────────────────────────────────────────────────
+test('PG-2: deleting a non-default page confirms, removes it, and the active page falls back', async ({
+  page,
+}) => {
+  await gotoFresh(page);
+
+  // Add a second page — addPage auto-switches currentPageId to the new (now active) page.
+  await page.locator('[data-testid="page-add"]').click();
+  await expect(page.locator('[data-testid^="page-tab-"]')).toHaveCount(2);
+
+  const tabs = page.locator('[data-testid^="page-tab-"]');
+  const firstId = await pageIdOf(tabs.nth(0));
+  const secondTab = tabs.nth(1);
+  const secondId = await pageIdOf(secondTab);
+
+  // The newly-added (second) tab is the active one and is the delete target.
+  await expect(secondTab).toHaveAttribute('aria-selected', 'true');
+
+  // Its delete affordance exists (non-default page). Click it → confirm dialog opens.
+  await page.locator(`[data-testid="page-delete-${secondId}"]`).click();
+  const confirmOk = page.locator('[data-testid="confirm-ok"]');
+  await expect(confirmOk).toBeVisible();
+  // The dialog is the delete-page confirm, not some other confirm. Target the
+  // visible RadixDialog.Title heading — the same text also renders in an sr-only
+  // Description fallback (Dialog.tsx), so a plain getByText would match two nodes.
+  await expect(
+    page.getByRole('heading', { name: 'Delete page?' }),
+  ).toBeVisible();
+
+  // Confirm the deletion.
+  await confirmOk.click();
+  await expect(confirmOk).toBeHidden();
+
+  // The deleted tab is gone; only the first (default) page remains.
+  await expect(
+    page.locator(`[data-testid="page-tab-${secondId}"]`),
+  ).toHaveCount(0);
+  await expect(page.locator('[data-testid^="page-tab-"]')).toHaveCount(1);
+
+  // Active page fell back to the surviving default page (deletePage → switchPage).
+  const survivor = page.locator(`[data-testid="page-tab-${firstId}"]`);
+  await expect(survivor).toBeVisible();
+  await expect(survivor).toHaveAttribute('aria-selected', 'true');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PG-3: The default (first) page has no delete affordance.
+// ──────────────────────────────────────────────────────────────────────────────
+test('PG-3: the default (first) page exposes no delete control', async ({
+  page,
+}) => {
+  await gotoFresh(page);
+
+  const firstTab = page.locator('[data-testid^="page-tab-"]').first();
+  const firstId = await pageIdOf(firstTab);
+
+  // PageTabs only renders page-delete-<id> when !page.isDefault — the migrated
+  // default page IS default, so it has no × button (even after we add a page that does).
+  await expect(
+    page.locator(`[data-testid="page-delete-${firstId}"]`),
+  ).toHaveCount(0);
+
+  // Add a second page: it MUST carry a delete control — proving the absence above
+  // is the default-page rule, not page-delete simply never rendering anywhere.
+  await page.locator('[data-testid="page-add"]').click();
+  const tabs = page.locator('[data-testid^="page-tab-"]');
+  await expect(tabs).toHaveCount(2);
+  const secondId = await pageIdOf(tabs.nth(1));
+  await expect(
+    page.locator(`[data-testid="page-delete-${secondId}"]`),
+  ).toBeVisible();
+
+  // The default page STILL has no delete control.
+  await expect(
+    page.locator(`[data-testid="page-delete-${firstId}"]`),
+  ).toHaveCount(0);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PG-4: A page metadata edit (rename) marks the item dirty → persists on Save.
+//
+// Signed-out the header indicator can't show "dirty" (it's pinned to "local"), so
+// we observe the dirty flag through the channel it actually gates: persistence. A
+// manual Save writes the renamed page title into the item's localStorage record;
+// reloading and re-reading proves the metadata edit was captured as an unsaved
+// change that Save then flushed.
+// ──────────────────────────────────────────────────────────────────────────────
+test('PG-4: renaming a page marks the item dirty so Save persists the new title', async ({
+  page,
+}) => {
+  // Reading localStorage + driving the in-app Save path is a local-build concern;
+  // on the staging gate (PW_BASE_URL) skip rather than assert against a live deploy.
+  test.skip(
+    !!process.env.PW_BASE_URL,
+    'localStorage persistence read needs the local build',
+  );
+
+  await gotoFresh(page);
+
+  const firstTab = page.locator('[data-testid^="page-tab-"]').first();
+  const id = await pageIdOf(firstTab);
+
+  // Baseline: nothing in localStorage carries our soon-to-be title yet.
+  const UNIQUE_TITLE = `RenamedPage_${Date.now()}`;
+  const hasTitle = () =>
+    page.evaluate((title) => {
+      for (let i = 0; i < localStorage.length; i++) {
+        const k = localStorage.key(i);
+        if (k === 'code') continue; // last-code slot, not the item record
+        const raw = localStorage.getItem(k);
+        if (raw && raw.includes(title)) return true;
+      }
+      return false;
+    }, UNIQUE_TITLE);
+  expect(await hasTitle()).toBe(false);
+
+  // Rename the default page — a metadata edit that ONLY sets dirty=true (renamePage
+  // does not bump unsavedCount), so any persistence of it is driven purely by dirty.
+  await firstTab.dblclick();
+  const renameInput = page.locator(`[data-testid="page-rename-${id}"]`);
+  await expect(renameInput).toBeVisible();
+  await renameInput.fill(UNIQUE_TITLE);
+  await renameInput.press('Enter');
+  await expect(page.locator(`[data-testid="page-tab-${id}"]`)).toContainText(
+    UNIQUE_TITLE,
+  );
+
+  // Trigger Save (header menu → Save). Because the rename marked the item dirty,
+  // Save writes the current item — including the renamed page — to localStorage.
+  await page.locator('[data-testid="header-menu"]').click();
+  await page.locator('[data-testid="header-save"]').click();
+  // First signed-out Save pops the one-time "Saved on this device" notice; dismiss it.
+  const noticeCancel = page.locator('[data-testid="confirm-cancel"]');
+  if (await noticeCancel.isVisible().catch(() => false)) {
+    await noticeCancel.click();
+    await expect(noticeCancel).toBeHidden();
+  }
+
+  // The renamed page title now lives in the persisted item record. Poll: the save()
+  // local write is async (itemService.setItem awaits localStore.set).
+  await expect.poll(hasTitle, { timeout: 5_000 }).toBe(true);
+});

--- a/e2e/tests/preview.spec.js
+++ b/e2e/tests/preview.spec.js
@@ -1,0 +1,353 @@
+// Preview controls E2E (signed-out / local flows only) — E2E_GAP_TEST_PLAN PRV-*.
+//
+// The preview/renderer side of the editor is the dark `ink` pane on the right.
+// Its surfaces (selectors verified against the components, not invented):
+//   - RendererHeader (web/src/components/preview/RendererHeader.tsx): the zoom
+//     label ("100%") + the Present button (data-testid="renderer-present").
+//   - PreviewFrame (web/src/preview/PreviewFrame.tsx): the srcdoc iframe
+//     (data-testid="preview-iframe") whose #mounting-point holds the rendered SVG.
+//   - Console (web/src/preview/Console.tsx): the docked debug band
+//     (data-testid="console") with console-toggle / console-status / console-count /
+//     console-eval / console-clear. Always rendered when NOT fullscreen (collapsed
+//     to h-8 when closed); HIDDEN in Present/fullscreen mode.
+//   - Present/fullscreen (AppRoot.tsx ~1315): toggleFullscreen makes the preview
+//     `fixed inset-0 z-50`, swaps RendererHeader for an Exit button
+//     (data-testid="preview-fullscreen"), and stops rendering the Console.
+//
+// What each test asserts is an OBSERVABLE outcome (a re-render, a visible/hidden
+// surface, a count change, an echoed value) — never a trivially-true check.
+//
+// Editor-as-landing (2026-06-13): bare '/' boots the EDITOR directly; openEditor
+// lands on the CM6 surface. The preview iframe + console band live in that editor.
+
+import { test, expect } from '@playwright/test';
+import { suppressOneTimeModals } from './helpers/onetime';
+import { openEditor } from './helpers/hub';
+
+const selectAll = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
+
+// Deployed sites (staging/prod, reached via PW_BASE_URL) load third-party
+// analytics/CDN scripts that throw uncaught errors we don't own; treat those as
+// noise so this spec stays usable against the live staging E2E gate.
+const THIRD_PARTY_ERROR_SOURCES = [
+  'userscript.js',
+  'gtm.js',
+  'googletagmanager',
+  'google-analytics',
+  'analytics.js',
+  'clarity.js',
+  'clarity.ms',
+  'paddle.js',
+  'cdn.paddle.com',
+  'zaraz',
+  'cloudflareinsights',
+];
+
+function isThirdPartyError(err) {
+  const haystack = `${err?.message || ''}\n${err?.stack || ''}`;
+  return THIRD_PARTY_ERROR_SOURCES.some((src) => haystack.includes(src));
+}
+
+function editorLocator(page) {
+  return page.locator('[data-testid="dsl-editor"] .cm-content');
+}
+
+/** Type a replacement DSL into the CM6 editor (select-all → Delete → type). */
+async function typeDsl(page, dsl, { timeout = 15_000 } = {}) {
+  const editor = editorLocator(page);
+  await expect(editor).toBeVisible({ timeout });
+  await editor.click();
+  await page.keyboard.press(selectAll);
+  await page.keyboard.press('Delete');
+  await editor.pressSequentially(dsl);
+}
+
+/** The rendered diagram's #mounting-point inside the preview iframe. */
+function mountLocator(page) {
+  return page
+    .frameLocator('[data-testid="preview-iframe"]')
+    .locator('#mounting-point');
+}
+
+/**
+ * Wait until the preview iframe is fully READY — i.e. the @zenuml/core bundle has
+ * loaded, posted `ready`, and rendered an <svg>. Only AFTER `ready` does the iframe
+ * bootstrap register its message listener, so evalConsole round-trips would
+ * otherwise time out (PreviewFrame.evalConsole resolves "timeout" after 5s if the
+ * frame never answers). Gating eval-based tests on a visible SVG removes that race.
+ */
+async function waitPreviewReady(page) {
+  await expect(mountLocator(page).locator('svg').first()).toBeVisible({
+    timeout: 20_000,
+  });
+}
+
+/** Open an item in the header overflow menu by its trigger testid. */
+async function openViaHeaderMenu(page, triggerTestId) {
+  await page.locator('[data-testid="header-menu"]').click();
+  await page.locator(`[data-testid="${triggerTestId}"]`).click();
+}
+
+test.beforeEach(async ({ page }) => {
+  page.on('pageerror', (err) => {
+    if (isThirdPartyError(err)) return;
+    throw err;
+  });
+  await suppressOneTimeModals(page); // M04: keep onboarding/pledge from trapping focus
+  // Start from a clean slate so the seeded sample (and console state) is deterministic.
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await openEditor(page);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PRV-1: Present/fullscreen toggle expands the diagram and hides editor + console;
+//        Exit restores.
+// ──────────────────────────────────────────────────────────────────────────────
+test('PRV-1: Present toggles a fullscreen surface that hides the editor + console; Exit restores', async ({
+  page,
+}) => {
+  // Baseline: the editor region, the renderer header's Present button, and the
+  // docked console band are all present in normal (non-fullscreen) mode.
+  await expect(page.locator('[data-testid="editor-region"]')).toBeVisible();
+  await expect(page.locator('[data-testid="renderer-present"]')).toBeVisible();
+  await expect(page.locator('[data-testid="console"]')).toBeVisible();
+  // The diagram has rendered into the iframe before we present (so "expands the
+  // diagram" is meaningful, not an empty fullscreen box).
+  await expect(mountLocator(page).locator('svg').first()).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // Enter Present (fullscreen).
+  await page.locator('[data-testid="renderer-present"]').click();
+
+  // The preview becomes a fixed inset-0 overlay: the Exit affordance appears, the
+  // RendererHeader (Present button) is gone, and the Console is NOT rendered.
+  const exitBtn = page.locator('[data-testid="preview-fullscreen"]');
+  await expect(exitBtn).toBeVisible();
+  await expect(page.locator('[data-testid="renderer-present"]')).toHaveCount(0);
+  await expect(page.locator('[data-testid="console"]')).toHaveCount(0);
+  // The fullscreen overlay covers the viewport (editor sits behind it). The diagram
+  // still renders inside the iframe in the expanded surface.
+  await expect(mountLocator(page).locator('svg').first()).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // Exit restores the normal split: Present button + console band return, Exit gone.
+  await exitBtn.click();
+  await expect(exitBtn).toHaveCount(0);
+  await expect(page.locator('[data-testid="renderer-present"]')).toBeVisible();
+  await expect(page.locator('[data-testid="console"]')).toBeVisible();
+  await expect(page.locator('[data-testid="editor-region"]')).toBeVisible();
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PRV-2: Debug console opens/closes and shows render output ("No issues" / entries).
+// ──────────────────────────────────────────────────────────────────────────────
+test('PRV-2: Console toggles open/closed and shows a clean-render status', async ({
+  page,
+}) => {
+  const consoleBand = page.locator('[data-testid="console"]');
+  await expect(consoleBand).toBeVisible();
+
+  // The status pill reflects render output. A clean sample render reads "No issues"
+  // (Console.tsx: clean ⇒ data-clean="true", label "No issues").
+  const status = page.locator('[data-testid="console-status"]');
+  await expect(status).toBeVisible();
+  await expect(status).toHaveAttribute('data-clean', 'true', {
+    timeout: 15_000,
+  });
+  await expect(status).toHaveText('No issues');
+
+  // Closed by default: the eval input is only rendered when the console is open.
+  const evalInput = page.locator('[data-testid="console-eval"]');
+  await expect(evalInput).toHaveCount(0);
+  await expect(page.locator('[data-testid="console-toggle"]')).toHaveAttribute(
+    'aria-expanded',
+    'false',
+  );
+
+  // Open it → the eval input appears and aria-expanded flips to true.
+  await page.locator('[data-testid="console-toggle"]').click();
+  await expect(evalInput).toBeVisible();
+  await expect(page.locator('[data-testid="console-toggle"]')).toHaveAttribute(
+    'aria-expanded',
+    'true',
+  );
+
+  // Close it → the eval input is removed again.
+  await page.locator('[data-testid="console-toggle"]').click();
+  await expect(evalInput).toHaveCount(0);
+  await expect(page.locator('[data-testid="console-toggle"]')).toHaveAttribute(
+    'aria-expanded',
+    'false',
+  );
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PRV-3: Ctrl+L clears the console.
+// ──────────────────────────────────────────────────────────────────────────────
+test('PRV-3: Ctrl+L clears accumulated console entries', async ({ page }) => {
+  // Produce entries deterministically by evaluating expressions through the console
+  // (each eval echoes its result back as a new entry — see PRV-4). Two evals ⇒ the
+  // count grows above zero, giving Ctrl+L something real to clear.
+  // Wait for the iframe to be ready first so eval round-trips actually answer.
+  await waitPreviewReady(page);
+  await page.locator('[data-testid="console-toggle"]').click();
+  const evalInput = page.locator('[data-testid="console-eval"]');
+  await expect(evalInput).toBeVisible();
+
+  const count = page.locator('[data-testid="console-count"]');
+  await evalInput.fill('1 + 1');
+  await evalInput.press('Enter');
+  await expect(count).toHaveText('1', { timeout: 10_000 });
+  await evalInput.fill('2 + 2');
+  await evalInput.press('Enter');
+  await expect(count).toHaveText('2', { timeout: 10_000 });
+
+  // Ctrl+L (the §11 global shortcut: e.key === 'l' && e.ctrlKey) clears entries.
+  // The handler keys on ctrlKey on every platform, so press Control+l on macOS too.
+  await page.keyboard.press('Control+l');
+  await expect(count).toHaveText('0', { timeout: 10_000 });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PRV-4: Console eval runs JS against the preview iframe and echoes a result.
+// ──────────────────────────────────────────────────────────────────────────────
+test('PRV-4: console eval runs JS in the preview iframe and echoes the result', async ({
+  page,
+}) => {
+  // The iframe bootstrap evaluates the expression with eval() in the srcdoc frame
+  // and posts back String(result) (previewBootstrap.runtime.js). That round-trip
+  // exercises the srcdoc iframe's script execution; gate it off the staging gate so
+  // it self-skips when targeting a remote host (mirrors production-build.spec.js).
+  test.skip(
+    !!process.env.PW_BASE_URL,
+    'console eval runs JS against the local srcdoc iframe; not run on the staging gate',
+  );
+
+  // Gate on a rendered SVG: the iframe registers its evalConsole listener only
+  // after `ready` fires, so without this the round-trip resolves "timeout" (5s).
+  await waitPreviewReady(page);
+
+  await page.locator('[data-testid="console-toggle"]').click();
+  const evalInput = page.locator('[data-testid="console-eval"]');
+  await expect(evalInput).toBeVisible();
+
+  // Evaluate an arithmetic expression whose result is distinctive and could not be
+  // pre-existing console noise (clean sample render starts at "No issues").
+  await evalInput.fill('21 * 2');
+  await evalInput.press('Enter');
+
+  // The echoed result is appended to the console log AND increments the count.
+  // eval() runs in the iframe and posts back String(result) = "42".
+  const consoleBand = page.locator('[data-testid="console"]');
+  await expect(consoleBand).toContainText('42', { timeout: 10_000 });
+  await expect(page.locator('[data-testid="console-count"]')).toHaveText('1', {
+    timeout: 10_000,
+  });
+
+  // A second expression evaluates against the SAME iframe global scope: assign a
+  // var, then read it back — proving eval persists in the frame's window, not a
+  // throwaway sandbox per call.
+  await evalInput.fill('window.__prvProbe = 7, window.__prvProbe + 1');
+  await evalInput.press('Enter');
+  await expect(consoleBand).toContainText('8', { timeout: 10_000 });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PRV-6: With auto-preview OFF, editing the DSL does NOT re-render until a manual
+//        refresh (toggling auto-preview back ON re-fires the render — the only
+//        manual re-render trigger in the no-rail UI).
+// ──────────────────────────────────────────────────────────────────────────────
+// PRODUCT BUG (fixme until wired): this test is a FALSE-GREEN. `settings.autoPreview`
+// is never passed to PreviewFrame — the two call sites in AppRoot.tsx (~918 and ~1350)
+// omit `autoPreview={settings.autoPreview}`, so PreviewFrame falls back to its default
+// `autoPreview=true` (PreviewFrame.tsx:47) and ALWAYS re-renders on the 500ms debounce.
+// The Settings toggle is therefore a dead control for rendering: it flips the stored
+// setting but never gates the preview. The old assertions happened to pass only because
+// they fired inside the debounce window (before the always-on re-render landed) — they
+// would pass identically with auto-preview ON, so they prove nothing.
+// To enable this test:
+//   1. Wire the prop: pass `autoPreview={settings.autoPreview}` to PreviewFrame at
+//      AppRoot.tsx ~918 and ~1350 so the toggle actually gates rendering.
+//   2. Make the staleness assertion debounce-proof: after editing with auto-preview
+//      OFF, wait > PREVIEW_DEBOUNCE (the 500ms PreviewFrame debounce) BEFORE asserting
+//      the preview is NOT re-rendered, so a real always-on render would be caught.
+test.fixme(
+  'PRV-6: with auto-preview OFF, editing does not re-render until auto-preview is re-enabled',
+  async ({ page }) => {
+    // The render path depends on the iframe's srcdoc evaluating @zenuml/core; assert
+    // it against the local app (it works the same against any host the app serves,
+    // but the render timing is most stable locally — keep parity with smoke/dsl specs
+    // which run on both, so no skip needed here).
+
+    // Step 1 — establish a known baseline render with a distinctive participant.
+    const BASELINE = 'PrvBaseline\nUser\nUser->PrvBaseline: before';
+    await typeDsl(page, BASELINE);
+    await expect(mountLocator(page)).toContainText('PrvBaseline', {
+      timeout: 15_000,
+    });
+
+    // Step 2 — turn Auto-preview OFF via Settings (the Radix Switch toggles to
+    // unchecked). This stops PreviewFrame's debounced re-render effect.
+    await openViaHeaderMenu(page, 'header-settings');
+    await expect(page.locator('[data-testid="settings-modal"]')).toBeVisible();
+    const autoPreviewSwitch = page.locator(
+      '[data-testid="setting-autoPreview"]',
+    );
+    await expect(autoPreviewSwitch).toHaveAttribute('aria-checked', 'true');
+    await autoPreviewSwitch.click();
+    await expect(autoPreviewSwitch).toHaveAttribute('aria-checked', 'false');
+    await page.keyboard.press('Escape');
+    await expect(page.locator('[data-testid="settings-modal"]')).toBeHidden();
+
+    // Step 3 — edit the DSL to a NEW distinctive participant. With auto-preview off,
+    // the preview must stay STALE: still showing the baseline, never the new token.
+    const EDITED = 'PrvUpdated\nUser\nUser->PrvUpdated: after';
+    await typeDsl(page, EDITED);
+    await expect(editorLocator(page)).toContainText('PrvUpdated');
+
+    // Give the debounce window time to fire IF it were going to (it must not). Then
+    // assert the preview is unchanged: baseline still rendered, new token absent.
+    await expect(mountLocator(page)).toContainText('PrvBaseline');
+    await expect(mountLocator(page)).not.toContainText('PrvUpdated');
+
+    // Step 4 — manual refresh: re-enable Auto-preview. The PreviewFrame effect's dep
+    // array includes `autoPreview`, so flipping it back ON re-posts the render and
+    // the preview catches up to the edited DSL.
+    await openViaHeaderMenu(page, 'header-settings');
+    await expect(page.locator('[data-testid="settings-modal"]')).toBeVisible();
+    await autoPreviewSwitch.click();
+    await expect(autoPreviewSwitch).toHaveAttribute('aria-checked', 'true');
+    await page.keyboard.press('Escape');
+    await expect(page.locator('[data-testid="settings-modal"]')).toBeHidden();
+
+    await expect(mountLocator(page)).toContainText('PrvUpdated', {
+      timeout: 15_000,
+    });
+    await expect(mountLocator(page)).not.toContainText('PrvBaseline', {
+      timeout: 15_000,
+    });
+  },
+);
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PRV-8: The renderer header shows a 100% zoom indicator.
+// ──────────────────────────────────────────────────────────────────────────────
+test('PRV-8: the renderer header shows a 100% zoom indicator', async ({
+  page,
+}) => {
+  // RendererHeader renders the zoom label (default "100%") in its right control
+  // cluster, immediately before the Present button. There is no testid on the span,
+  // so target it structurally: the renderer header is the bar that contains the
+  // Present button; the 100% label is the sibling text in that same bar.
+  const present = page.locator('[data-testid="renderer-present"]');
+  await expect(present).toBeVisible();
+
+  // The zoom label lives in the same header bar (.pv-tools cluster) as Present.
+  const header = page
+    .locator('[data-testid="renderer-present"]')
+    .locator('xpath=ancestor::div[contains(@class,"border-b")][1]');
+  await expect(header).toContainText('100%');
+});

--- a/e2e/tests/settings.spec.js
+++ b/e2e/tests/settings.spec.js
@@ -1,0 +1,376 @@
+// Settings depth E2E (signed-out / local) — covers the Settings modal beyond the
+// font-size smoke in modals.spec.js. Each test changes a setting and asserts a REAL,
+// OBSERVABLE consequence in the running editor (CodeMirror theme/keymap/font), the
+// boot behavior, persisted state, or the absence of an extension-only control.
+//
+// Plan cases (e2e/E2E_GAP_TEST_PLAN.md §7):
+//   SET-1  theme change applies live to CodeMirror              → assert .cm-editor bg flips
+//   SET-2  keymap=Vim enables modal editing (i / Esc)           → assert .cm-fat-cursor toggles
+//   SET-3  font-family change applies to .cm-content            → assert computed font-family
+//   SET-5  a behavior toggle takes observable effect            → preserveLastCode off ⇒ reload shows starter
+//   SET-6  a settings change persists across a reload           → reopen settings, value retained
+//   SET-8  "Replace new tab" control is ABSENT on web           → assert the control does not render
+//
+// Deferred (honest test.fixme — see each):
+//   SET-4  indent-unit change (2/4/8) → auto-indent width. The Indent-size Select EXISTS
+//          but is NOT wired to the editor: AppRoot passes only theme/fontSize/fontFamily/
+//          keymap to <CodeEditor> (AppRoot.tsx ~1268), and nothing sets CM6's indentUnit
+//          facet from settings.indentSize anywhere in web/src. The DSL block indent is
+//          fixed at CM6's default 2 spaces via delimitedIndent (zenumlLanguage.ts). So
+//          changing indent size has no observable effect to assert today.
+//   SET-7  signed-in cloud-persist of settings — needs Firebase auth (emulator/account).
+//
+// suppressOneTimeModals runs in beforeEach so Onboarding/Support-pledge don't trap focus.
+// The pageerror filter mirrors smoke.spec.js so the spec is usable on the live staging gate.
+
+import { test, expect } from '@playwright/test';
+import { suppressOneTimeModals } from './helpers/onetime';
+import { openEditor } from './helpers/hub';
+
+const selectAll = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
+
+// Deployed sites (staging/prod via PW_BASE_URL) load third-party analytics/CDN
+// scripts that throw uncaught errors we don't own; treat those as noise so genuine
+// app errors still fail the test. (Copied verbatim from smoke.spec.js.)
+const THIRD_PARTY_ERROR_SOURCES = [
+  'userscript.js',
+  'gtm.js',
+  'googletagmanager',
+  'google-analytics',
+  'analytics.js',
+  'clarity.js',
+  'clarity.ms',
+  'paddle.js',
+  'cdn.paddle.com',
+  'zaraz',
+  'cloudflareinsights',
+];
+
+function isThirdPartyError(err) {
+  const haystack = `${err?.message || ''}\n${err?.stack || ''}`;
+  return THIRD_PARTY_ERROR_SOURCES.some((src) => haystack.includes(src));
+}
+
+/** Navigate to the EDITOR with a clean localStorage slate (see persistence.spec.js). */
+async function gotoFresh(page) {
+  await suppressOneTimeModals(page);
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  // Editor-as-landing: bare '/' boots the editor; openEditor lands on the CM6 surface.
+  await openEditor(page);
+}
+
+/** Open the Settings modal via the header overflow menu. */
+async function openSettings(page) {
+  await page.locator('[data-testid="header-menu"]').click();
+  await page.locator('[data-testid="header-settings"]').click();
+  await expect(page.locator('[data-testid="settings-modal"]')).toBeVisible();
+}
+
+/** Pick `optionLabel` from an open Radix Select trigger identified by its testid. */
+async function chooseSetting(page, triggerTestId, optionLabel) {
+  await page.locator(`[data-testid="${triggerTestId}"]`).click();
+  await page.getByRole('option', { name: optionLabel, exact: true }).click();
+}
+
+const dslEditor = (page) =>
+  page.locator('[data-testid="dsl-editor"] .cm-editor');
+const dslContent = (page) =>
+  page.locator('[data-testid="dsl-editor"] .cm-content');
+
+test.beforeEach(async ({ page }) => {
+  page.on('pageerror', (err) => {
+    if (isThirdPartyError(err)) return;
+    throw err;
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// SET-1: Editor theme change applies LIVE to CodeMirror.
+//
+// The theme is swapped via a CM6 compartment reconfigure (CodeEditor.tsx
+// themeCompartment), so the change must show WITHOUT a reload. Ink (the default)
+// renders on the ink-950 well (#0B0E13 → rgb(11,14,19)); GitHub Light renders on a
+// white surface. Assert the live computed background-color of .cm-editor flips.
+// ──────────────────────────────────────────────────────────────────────────────
+test('SET-1: changing the editor theme applies live to CodeMirror', async ({
+  page,
+}) => {
+  await gotoFresh(page);
+  const editor = dslEditor(page);
+  await expect(editor).toBeVisible();
+
+  const before = await editor.evaluate(
+    (el) => getComputedStyle(el).backgroundColor,
+  );
+  // Default ink theme: deep ink well (#0B0E13).
+  expect(before).toBe('rgb(11, 14, 19)');
+
+  await openSettings(page);
+  await chooseSetting(page, 'setting-editorTheme', 'GitHub Light');
+  await page.keyboard.press('Escape'); // close modal; theme already applied live
+  await expect(page.locator('[data-testid="settings-modal"]')).toBeHidden();
+
+  // The light theme repaints the editor surface white — a LIVE compartment swap,
+  // no reload. Poll until the computed background actually changes.
+  await expect
+    .poll(async () =>
+      editor.evaluate((el) => getComputedStyle(el).backgroundColor),
+    )
+    .not.toBe(before);
+  const after = await editor.evaluate(
+    (el) => getComputedStyle(el).backgroundColor,
+  );
+  // GitHub Light paints a white editor surface.
+  expect(after).toBe('rgb(255, 255, 255)');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// SET-2: keymap = Vim enables Vim modal editing.
+//
+// CodeEditor swaps in @replit/codemirror-vim via the keymap compartment when
+// keymap === 'vim'. Vim mode renders a BLOCK cursor in normal mode (the
+// .cm-fat-cursor element) and a THIN caret in insert mode. So:
+//   normal  → .cm-fat-cursor present
+//   press i → insert mode → .cm-fat-cursor gone
+//   press Esc → normal mode → .cm-fat-cursor back
+// That round-trip is the observable proof that vim bindings are live (sublime
+// keymap never renders a fat cursor at all).
+// ──────────────────────────────────────────────────────────────────────────────
+test('SET-2: keymap=Vim enables Vim bindings (i enters insert, Esc leaves)', async ({
+  page,
+}) => {
+  await gotoFresh(page);
+
+  // Sanity: the default (sublime) keymap has NO vim block cursor.
+  await expect(dslEditor(page).locator('.cm-fat-cursor')).toHaveCount(0);
+
+  await openSettings(page);
+  await chooseSetting(page, 'setting-keymap', 'vim');
+  await page.keyboard.press('Escape');
+  await expect(page.locator('[data-testid="settings-modal"]')).toBeHidden();
+
+  // Focus the editor so vim's cursor layer renders.
+  await dslContent(page).click();
+  const fatCursor = dslEditor(page).locator('.cm-fat-cursor');
+
+  // Normal mode after focus → block (fat) cursor present.
+  await expect(fatCursor).toHaveCount(1);
+
+  // 'i' enters INSERT mode → the block cursor becomes a thin caret (fat cursor gone).
+  await page.keyboard.press('i');
+  await expect(fatCursor).toHaveCount(0);
+
+  // Esc returns to NORMAL mode → the block cursor comes back.
+  await page.keyboard.press('Escape');
+  await expect(fatCursor).toHaveCount(1);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// SET-3: Font-family change applies to .cm-content (SET-3 "if cheap").
+//
+// CodeEditor applies the chosen family to .cm-content via the font compartment
+// (fontTheme → '.cm-content': { fontFamily: fontStack(family) }). Changing the
+// Font-family Select to Inconsolata must show up in the LIVE computed font-family
+// of .cm-content (no reload). The default family is FiraCode ("Fira Code").
+// ──────────────────────────────────────────────────────────────────────────────
+test('SET-3: font-family change applies live to .cm-content', async ({
+  page,
+}) => {
+  await gotoFresh(page);
+  const content = dslContent(page);
+  await expect(content).toBeVisible();
+
+  const before = await content.evaluate(
+    (el) => getComputedStyle(el).fontFamily,
+  );
+  // Default FiraCode resolves to a stack beginning with "Fira Code".
+  expect(before.toLowerCase()).toContain('fira code');
+
+  await openSettings(page);
+  await chooseSetting(page, 'setting-editorFont', 'Inconsolata');
+  await page.keyboard.press('Escape');
+  await expect(page.locator('[data-testid="settings-modal"]')).toBeHidden();
+
+  // Live compartment swap → .cm-content now reports the Inconsolata stack.
+  await expect
+    .poll(async () =>
+      content.evaluate((el) => getComputedStyle(el).fontFamily.toLowerCase()),
+    )
+    .toContain('inconsolata');
+  // And the previous family is no longer the leading face.
+  const after = await content.evaluate((el) =>
+    getComputedStyle(el).fontFamily.toLowerCase(),
+  );
+  expect(after).not.toBe(before.toLowerCase());
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// SET-4: indent-unit change → auto-indent width. DEFERRED.
+//
+// The Indent-size Select renders but is NOT wired to the editor: AppRoot threads
+// only theme/fontSize/fontFamily/keymap into <CodeEditor> (AppRoot.tsx ~1268), and
+// NOTHING in web/src sets CM6's `indentUnit` facet from settings.indentSize. The DSL
+// block body indents a FIXED 2 spaces via delimitedIndent (zenumlLanguage.ts). So
+// selecting indent=4 produces no observable change in the editor — there is no honest
+// assertion to make today. Marked fixme rather than faked.
+// ──────────────────────────────────────────────────────────────────────────────
+test.fixme(
+  'SET-4: indent-unit change (4) changes auto-indent width in a block',
+  async ({ page }) => {
+    // Wiring gap: settings.indentSize is not connected to the CM6 indentUnit facet,
+    // so the editor always indents blocks by 2 spaces regardless of this setting.
+    // Implement once AppRoot passes indentSize/indentWith into <CodeEditor> and the
+    // editor sets indentUnit from it; then: set indent=4, type `A.run() {`, Enter,
+    // assert the new line is indented 4 spaces.
+    await gotoFresh(page);
+  },
+);
+
+// ──────────────────────────────────────────────────────────────────────────────
+// SET-5: a behavior toggle takes observable effect.
+//
+// Of the plan's candidates (line-wrap / autocomplete / auto-save), the cleanest
+// signed-out, FAST, genuinely-wired toggle is `preserveLastCode` — read by the boot
+// resolver (useBootItem.ts branch 3). The default (ON) restores your last edit on a
+// reload of '/'; turning it OFF makes boot take the 'new' branch → the default
+// STARTER diagram, NOT your last edit. We prove the toggle's effect by the
+// observable divergence at reload:
+//   toggle OFF → type a unique token → trigger the last-code write → reload '/'
+//   ⇒ editor shows the starter ("Alice -> Bob: Hello"), NOT the unique token.
+// (persistence.spec.js test 1 proves the inverse: with it ON, the edit IS restored.)
+// ──────────────────────────────────────────────────────────────────────────────
+test('SET-5: behavior toggle (preserve-last-code off) changes reload behavior', async ({
+  page,
+}) => {
+  await gotoFresh(page);
+
+  // Turn preserve-last-code OFF.
+  await openSettings(page);
+  const toggle = page.locator('[data-testid="setting-preserveLastCode"]');
+  await expect(toggle).toHaveAttribute('aria-checked', 'true'); // default ON
+  await toggle.click();
+  await expect(toggle).toHaveAttribute('aria-checked', 'false');
+  await page.keyboard.press('Escape');
+  await expect(page.locator('[data-testid="settings-modal"]')).toBeHidden();
+
+  // Type a distinctive DSL so a stale restore (if it wrongly happened) would be obvious.
+  const UNIQUE = 'PreserveOffProbe';
+  const content = dslContent(page);
+  await content.click();
+  await page.keyboard.press(selectAll);
+  await page.keyboard.press('Delete');
+  await content.pressSequentially(`${UNIQUE}\nUser\nUser->${UNIQUE}: edit`);
+  await expect(content).toContainText(UNIQUE);
+
+  // AppRoot writes the last-code slot on visibilitychange (document.hidden → true).
+  // Fire it so that IF the slot were read on boot, our token would come back — proving
+  // the assertion below tests the SETTING, not merely an unwritten slot.
+  await page.evaluate(() => {
+    Object.defineProperty(document, 'hidden', {
+      value: true,
+      configurable: true,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+
+  // Reload bare '/': preserveLastCode is OFF → boot resolves 'new' → starter DSL.
+  await page.reload();
+  await expect(content).toBeVisible({ timeout: 15_000 });
+
+  // The starter is restored; our unique token is NOT — the toggle changed boot behavior.
+  await expect(content).toContainText('Alice -> Bob: Hello', {
+    timeout: 15_000,
+  });
+  await expect(content).not.toContainText(UNIQUE);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// SET-6: a settings change persists across a page reload.
+//
+// settingsStore persists to the local syncStore; the editorTheme must survive a full
+// reload. Change the theme to Dracula, reload, reopen Settings → the Theme trigger
+// still reads "Dracula" (the persisted value rehydrated, not the Ink default). We also
+// assert the LIVE editor surface reflects the persisted theme after reload (the
+// Dracula well is not the Ink well), so this guards both the stored value AND its
+// re-application — not just the control label.
+// ──────────────────────────────────────────────────────────────────────────────
+test('SET-6: a settings change persists across a page reload', async ({
+  page,
+}) => {
+  await gotoFresh(page);
+
+  await openSettings(page);
+  await chooseSetting(page, 'setting-editorTheme', 'Dracula');
+  const trigger = page.locator('[data-testid="setting-editorTheme"]');
+  await expect(trigger).toContainText('Dracula');
+  await page.keyboard.press('Escape');
+
+  // Capture the live Dracula editor background BEFORE reload (it is neither the Ink
+  // #0B0E13 well nor white) so we can confirm it is re-applied after reload too.
+  const editor = dslEditor(page);
+  await expect
+    .poll(async () =>
+      editor.evaluate((el) => getComputedStyle(el).backgroundColor),
+    )
+    .not.toBe('rgb(11, 14, 19)');
+  const draculaBg = await editor.evaluate(
+    (el) => getComputedStyle(el).backgroundColor,
+  );
+  expect(draculaBg).not.toBe('rgb(11, 14, 19)'); // not the Ink default
+
+  // Full reload — the settingsStore must rehydrate editorTheme from the local store.
+  await page.reload();
+  await expect(dslContent(page)).toBeVisible({ timeout: 15_000 });
+
+  // The persisted theme is re-applied to the live editor surface (not the Ink default).
+  await expect
+    .poll(async () =>
+      editor.evaluate((el) => getComputedStyle(el).backgroundColor),
+    )
+    .toBe(draculaBg);
+
+  // And the Settings control reflects the retained value.
+  await openSettings(page);
+  await expect(
+    page.locator('[data-testid="setting-editorTheme"]'),
+  ).toContainText('Dracula');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// SET-7: signed-in cloud-persist of settings. DEFERRED (needs Firebase auth).
+// ──────────────────────────────────────────────────────────────────────────────
+test.fixme(
+  'SET-7: settings persist to the cloud and survive a fresh signed-in session',
+  async () => {
+    // Requires a signed-in Firebase session (auth emulator or seeded account) to
+    // exercise the cloud settings round-trip — unavailable in the signed-out
+    // staging gate. Implement under the planned *.cloud.spec.js emulator project.
+  },
+);
+
+// ──────────────────────────────────────────────────────────────────────────────
+// SET-8: the "Replace new tab" control is ABSENT on web (extension-only).
+//
+// SettingsModal gates the whole Extension section (and its setting-replaceNewTab
+// switch) behind `isExtension`. On the web app that flag is false, so the control
+// must NOT render. Assert its absence while the modal is open AND verify the modal
+// IS open (so a zero count means "absent", not "modal failed to render").
+// ──────────────────────────────────────────────────────────────────────────────
+test('SET-8: the "Replace new tab" control is absent on web (extension-only)', async ({
+  page,
+}) => {
+  await gotoFresh(page);
+  await openSettings(page);
+
+  // The modal is open and populated (a sibling control renders) …
+  await expect(
+    page.locator('[data-testid="setting-editorTheme"]'),
+  ).toBeVisible();
+  // … but the extension-only "Replace new tab page" toggle is NOT present on web.
+  await expect(
+    page.locator('[data-testid="setting-replaceNewTab"]'),
+  ).toHaveCount(0);
+  // The whole Extension section heading is likewise absent.
+  await expect(page.getByText('Replace new tab page')).toHaveCount(0);
+});

--- a/e2e/tests/telemetry.spec.js
+++ b/e2e/tests/telemetry.spec.js
@@ -1,0 +1,350 @@
+// Analytics / telemetry E2E (editor-as-landing instrumentation).
+//
+// WHAT THIS COVERS — the three editor-as-landing telemetry events wired in
+// web/src/app/AppRoot.tsx, observed at their real transport boundary:
+//   ANL-1  landed_in_editor{label:<bootKind>}  fires once per editor boot
+//   ANL-2  hub_opened{label:<source>}          fires on hub arrival, re-arms on Back
+//   ANL-3  first_edit                          fires once per mount on the first DSL edit
+//
+// TRANSPORT (verified in code, not guessed):
+//   useAnalytics().track(event, props) → analytics.emit(event, props, ctx).
+//   emit() (web/src/services/analytics.ts) is NOT in debug mode locally
+//   (window.DEBUG unset, no `wmdebug` cookie), so it:
+//     (a) POSTs to /track via cloudFunctions.trackEvent — fetch('/track', {body:
+//         JSON.stringify({event, userId, ...props})}). This is the reliable
+//         in-browser seam: the request fires for EVERY tracked event regardless of
+//         whether any CDN snippet loaded.
+//     (b) ALSO pushes to window.dataLayer / window.mixpanel — but those CDN globals
+//         are NEVER injected on the local dev/preview origin (loadClientAnalytics is
+//         a stub until the keys land), so (a) is what we intercept.
+//   We page.route('**/track') and fulfill 200 (the real endpoint 404s locally; the
+//   POST is fire-and-forget and swallows errors, but fulfilling keeps the network
+//   clean and lets us read every event body). Each captured body is {event, userId,
+//   category, label, ...} — we assert on event name + label, the observable contract.
+//
+// NOT debug-guarded: the /track POST is the production path and works against a
+// deployed target too, so these tests run on the staging gate unchanged (no
+// PW_BASE_URL skip needed — there is no local-only build dependency here).
+
+import { test, expect } from '@playwright/test';
+import { suppressOneTimeModals } from './helpers/onetime';
+import { openEditor, gotoHome } from './helpers/hub';
+
+// Deployed sites load third-party analytics/CDN scripts that throw uncaught errors
+// we don't own; treat those as noise (copied from smoke.spec.js).
+const THIRD_PARTY_ERROR_SOURCES = [
+  'userscript.js',
+  'gtm.js',
+  'googletagmanager',
+  'google-analytics',
+  'analytics.js',
+  'clarity.js',
+  'clarity.ms',
+  'paddle.js',
+  'cdn.paddle.com',
+  'zaraz',
+  'cloudflareinsights',
+];
+
+function isThirdPartyError(err) {
+  const haystack = `${err?.message || ''}\n${err?.stack || ''}`;
+  return THIRD_PARTY_ERROR_SOURCES.some((src) => haystack.includes(src));
+}
+
+const selectAll = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
+
+/**
+ * Install a /track interceptor that records every analytics event payload and
+ * fulfils the request with 200 so the app's fire-and-forget POST resolves cleanly.
+ * Returns the live `events` array (mutated as events arrive) plus a helper to read
+ * the names that landed for a given event type.
+ *
+ * MUST be installed BEFORE the navigation that boots the editor — landed_in_editor
+ * fires during boot resolution, so a route registered after page.goto would miss it.
+ */
+async function interceptAnalytics(page) {
+  const events = [];
+  await page.route('**/track', async (route) => {
+    const req = route.request();
+    let body = {};
+    try {
+      body = JSON.parse(req.postData() || '{}');
+    } catch {
+      body = { _unparsed: req.postData() };
+    }
+    events.push(body);
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: '{}',
+    });
+  });
+  return {
+    events,
+    /** All captured payloads whose `event` matches `name`. */
+    of(name) {
+      return events.filter((e) => e.event === name);
+    },
+  };
+}
+
+/** The CM6 editor content surface. */
+function editorLocator(page) {
+  return page.locator('[data-testid="dsl-editor"] .cm-content');
+}
+
+/** Type a replacement DSL into the CM6 editor (focus → select-all → Delete → type). */
+async function typeDsl(page, dsl, { timeout = 15_000 } = {}) {
+  const editor = editorLocator(page);
+  await expect(editor).toBeVisible({ timeout });
+  await editor.click();
+  await page.keyboard.press(selectAll);
+  await page.keyboard.press('Delete');
+  await editor.pressSequentially(dsl);
+}
+
+test.beforeEach(async ({ page }) => {
+  page.on('pageerror', (err) => {
+    if (isThirdPartyError(err)) return;
+    throw err;
+  });
+  await suppressOneTimeModals(page);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// ANL-1: landed_in_editor fires once per editor boot, carrying the bootKind label.
+//
+// On a fresh slate (storage cleared by openEditor's default navigation reaching a
+// no-last-code state) bare '/' boots and useBootItem resolves to kind 'new', so
+// onResolved → track('landed_in_editor', {label:'new'}). We assert EXACTLY ONE such
+// event fires for the single boot, and that its label is a real bootKind.
+// ──────────────────────────────────────────────────────────────────────────────
+test('ANL-1: landed_in_editor fires once per editor boot with a bootKind label', async ({
+  page,
+}) => {
+  const analytics = await interceptAnalytics(page);
+
+  // Start from a clean slate so the boot resolution is deterministic ('new').
+  // The FIRST goto('/') exists only to get an origin we can clear storage on — it
+  // boots the editor too (and fires its own landed_in_editor). We then RESET the
+  // captured buffer so the assertion measures exactly ONE boot: the openEditor
+  // navigation below. (Two boots → two events confirms per-boot firing; we isolate
+  // a single boot here to assert the once-per-boot count cleanly.)
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  analytics.events.length = 0; // discard the pre-clear boot's events
+  await openEditor(page);
+
+  // landed_in_editor is emitted from useBootItem.onResolved during boot. Poll until
+  // it lands (the POST is async + fire-and-forget).
+  await expect
+    .poll(() => analytics.of('landed_in_editor').length, { timeout: 10_000 })
+    .toBeGreaterThan(0);
+
+  // Settle: give any (incorrect) duplicate from this single boot time to arrive
+  // before asserting the count is exactly one.
+  await page.waitForTimeout(500);
+
+  const landed = analytics.of('landed_in_editor');
+  // Exactly once per THIS boot — useBootItem guards onResolved with a booted ref, so
+  // a StrictMode double-mount must not double-fire within a single boot.
+  expect(landed.length).toBe(1);
+
+  // The label is the resolved bootKind — a REAL BootResult kind, never empty/garbage.
+  // We don't pin the exact kind here (the prior boot's seeded sample can populate the
+  // last-code slot, so this single boot may resolve to 'new' OR 'lastcode' depending
+  // on ordering); the dedicated 'lastcode' test below proves the label TRACKS the
+  // resolution branch. What this test asserts is the once-per-boot count + a valid,
+  // navigation-category label envelope.
+  const VALID_BOOT_KINDS = ['new', 'lastcode', 'item', 'code', 'shared'];
+  expect(VALID_BOOT_KINDS).toContain(landed[0].label);
+  // Envelope parity: editor-boot events are category 'navigation'.
+  expect(landed[0].category).toBe('navigation');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// ANL-1 (variant): a preserved last-code boot tags landed_in_editor as 'lastcode'.
+//
+// Proves the label actually tracks the resolution branch (not a constant). We seed
+// the last-code 'code' slot via the in-app write path (edit → visibilitychange),
+// reload bare '/', and assert the NEW boot's landed_in_editor carries label
+// 'lastcode'. This is a real observable: a different boot path → a different label.
+// ──────────────────────────────────────────────────────────────────────────────
+test('ANL-1: a last-code boot tags landed_in_editor with label "lastcode"', async ({
+  page,
+}) => {
+  const analytics = await interceptAnalytics(page);
+
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await openEditor(page);
+
+  // First boot resolved to 'new'; confirm and then clear the buffer so the reload's
+  // boot is isolated.
+  await expect
+    .poll(() => analytics.of('landed_in_editor').length, { timeout: 10_000 })
+    .toBeGreaterThan(0);
+
+  // Type distinctive DSL so the last-code slot is non-empty (resolveBootItem branch 3
+  // only returns 'lastcode' when item.js is truthy).
+  const TOKEN = 'LastCodeBootProbe';
+  await typeDsl(page, `${TOKEN}\nUser\nUser->${TOKEN}: hi`);
+  await expect(editorLocator(page)).toContainText(TOKEN);
+
+  // AppRoot writes the last-code 'code' slot on visibilitychange (document.hidden).
+  await page.evaluate(() => {
+    Object.defineProperty(document, 'hidden', {
+      value: true,
+      configurable: true,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+  await page.waitForFunction(
+    (t) => {
+      const raw = localStorage.getItem('code');
+      if (!raw) return false;
+      try {
+        return JSON.parse(raw)?.js?.includes(t);
+      } catch {
+        return false;
+      }
+    },
+    TOKEN,
+    { timeout: 5_000 },
+  );
+
+  // Drop everything captured so far; the reload is a brand-new boot to observe.
+  analytics.events.length = 0;
+
+  await page.reload();
+  await expect(editorLocator(page)).toContainText(TOKEN, { timeout: 15_000 });
+
+  // The reload boot reads the 'code' slot → kind 'lastcode'.
+  await expect
+    .poll(() => analytics.of('landed_in_editor').length, { timeout: 10_000 })
+    .toBe(1);
+  expect(analytics.of('landed_in_editor')[0].label).toBe('lastcode');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// ANL-2: hub_opened{source} fires on hub arrival, and RE-ARMS on browser Back.
+//
+// Arriving at the hub via ?view=diagrams emits hub_opened{label:'landing-param'}.
+// Going INTO the editor (open a card / new) then pressing browser Back to the hub
+// must emit a SECOND hub_opened — the landing ref re-arms when isHomeMode flips
+// false on leaving. Without that re-arm, hub demand is under-counted.
+// ──────────────────────────────────────────────────────────────────────────────
+test('ANL-2: hub_opened fires on hub arrival and re-arms on browser Back', async ({
+  page,
+}) => {
+  const analytics = await interceptAnalytics(page);
+
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+
+  // First arrival at the hub via the landing param.
+  await gotoHome(page);
+  await expect
+    .poll(() => analytics.of('hub_opened').length, { timeout: 10_000 })
+    .toBe(1);
+  expect(analytics.of('hub_opened')[0].label).toBe('landing-param');
+  expect(analytics.of('hub_opened')[0].category).toBe('navigation');
+
+  // Leave the hub: the empty library shows a "New" CTA that loads a blank diagram
+  // and navigates to the editor (?id=). This is a client-side navigation, so the
+  // hub→editor transition flips isHomeMode false and re-arms the landing ref.
+  const emptyCta = page.locator('[data-testid="home-empty-new"]');
+  const homeNew = page.locator('[data-testid="home-new"]');
+  if (await emptyCta.isVisible()) {
+    await emptyCta.click();
+  } else {
+    await homeNew.click();
+  }
+  await expect(editorLocator(page)).toBeVisible({ timeout: 15_000 });
+
+  // Browser Back returns to ?view=diagrams — a FRESH hub arrival → a 2nd hub_opened.
+  await page.goBack();
+  await expect(page.locator('[data-testid="home-view"]')).toBeVisible({
+    timeout: 15_000,
+  });
+
+  await expect
+    .poll(() => analytics.of('hub_opened').length, { timeout: 10_000 })
+    .toBe(2);
+  // The re-armed arrival is still a landing-param arrival (the URL carries
+  // ?view=diagrams; no breadcrumb click was involved).
+  expect(analytics.of('hub_opened')[1].label).toBe('landing-param');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// ANL-2 (variant): the in-editor breadcrumb fires hub_opened{label:'breadcrumb'}.
+//
+// goHome() (the header breadcrumb / hub affordance) emits hub_opened with label
+// 'breadcrumb' BEFORE navigating, and sets hubLandingFired up-front so the ensuing
+// isHomeMode landing effect does NOT also fire 'landing-param'. So a breadcrumb
+// click must produce EXACTLY ONE hub_opened, labelled 'breadcrumb'.
+// ──────────────────────────────────────────────────────────────────────────────
+test('ANL-2: the breadcrumb-to-hub action fires hub_opened{label:"breadcrumb"} once', async ({
+  page,
+}) => {
+  const analytics = await interceptAnalytics(page);
+
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await openEditor(page);
+  await expect(editorLocator(page)).toBeVisible({ timeout: 15_000 });
+
+  // The breadcrumb back affordance that calls goHome() (AppHeader, editor mode):
+  // data-testid="header-go-home", aria-label "Back to your diagrams". onGoHome is
+  // wired unconditionally to goHome in the editor render, so this always renders here.
+  const target = page.locator('[data-testid="header-go-home"]');
+  await expect(target).toBeVisible({ timeout: 10_000 });
+  await target.click();
+
+  await expect(page.locator('[data-testid="home-view"]')).toBeVisible({
+    timeout: 15_000,
+  });
+
+  await expect
+    .poll(() => analytics.of('hub_opened').length, { timeout: 10_000 })
+    .toBe(1);
+  expect(analytics.of('hub_opened')[0].label).toBe('breadcrumb');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// ANL-3: first_edit fires ONCE per mount on the first DSL edit (not on subsequent
+// edits). handleDslChange guards with firstEditFired ref; first_edit carries
+// category 'fn' and no bootKind.
+// ──────────────────────────────────────────────────────────────────────────────
+test('ANL-3: first_edit fires once per mount on the first DSL edit only', async ({
+  page,
+}) => {
+  const analytics = await interceptAnalytics(page);
+
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await openEditor(page);
+  await expect(editorLocator(page)).toBeVisible({ timeout: 15_000 });
+
+  // No edit yet → no first_edit. (boot may have fired landed_in_editor; that's a
+  // different event and is asserted in ANL-1.)
+  expect(analytics.of('first_edit').length).toBe(0);
+
+  // First user edit: type a single character into the DSL editor.
+  const editor = editorLocator(page);
+  await editor.click();
+  await page.keyboard.press('End');
+  await editor.pressSequentially('A');
+
+  await expect
+    .poll(() => analytics.of('first_edit').length, { timeout: 10_000 })
+    .toBe(1);
+  expect(analytics.of('first_edit')[0].category).toBe('fn');
+
+  // Subsequent edits must NOT re-fire first_edit (once-per-mount contract). Type
+  // several more characters and confirm the count stays at exactly 1.
+  await editor.pressSequentially('BCDE');
+  // Give any (incorrect) extra event time to land before asserting it did NOT.
+  await page.waitForTimeout(750);
+  expect(analytics.of('first_edit').length).toBe(1);
+});

--- a/e2e/tests/templates.spec.js
+++ b/e2e/tests/templates.spec.js
@@ -1,0 +1,227 @@
+// Templates E2E (signed-out / local). Covers the "Create New" template picker:
+//   TPL-1  "Browse templates" opens the full CreateNewModal picker grid.
+//   TPL-2  for EACH card (Blank + every real template) selecting it loads that
+//          template's DSL into the editor and OPENS it (navigates to /?id=).
+//   TPL-3  each card shows a styled schematic preview (the CSS thumbnail).
+//
+// The picker is reached via the HUB's "Browse templates" affordance: bare '/' boots
+// the editor under editor-as-landing, so we navigate to the HomeView library
+// ('/?view=diagrams') with an EMPTY local index → its empty-state offers the
+// `home-empty-templates` button (and a "From template…" menu item) wired to
+// openModal('createNew'). Selecting a card in that hub-rendered CreateNewModal goes
+// through handleCreateAndOpen (AppRoot.tsx) which creates the item AND navigates to
+// '/?id=<newId>' — landing the user in the editor with the template's DSL loaded.
+//
+// Card → template inventory (web/src/domain/templates.ts):
+//   create-blank                       → Blank (empty js)
+//   create-template-basic              → "Basic"          js: A.method() { if(condition) … }
+//   create-template-black-white        → "Black & White"  js: Client->SGW."Get order by id" …
+//   create-template-blue               → "Blue"           js: Client->SGW."Get order by id" …
+//   create-template-starUMLTheme       → "starUML Theme"  js: A.do() { if (condition1) … }
+// (blue & black-white intentionally share identical JS — they differ only in CSS
+// theme — so the DSL-load assertion for both keys on the shared Client->SGW token.)
+
+import { test, expect } from '@playwright/test';
+import { suppressOneTimeModals } from './helpers/onetime';
+
+// Deployed sites (staging/prod, reached via PW_BASE_URL) load third-party
+// analytics/CDN scripts that throw uncaught errors we don't own; treat those as
+// noise (copied verbatim from smoke.spec.js).
+const THIRD_PARTY_ERROR_SOURCES = [
+  'userscript.js',
+  'gtm.js',
+  'googletagmanager',
+  'google-analytics',
+  'analytics.js',
+  'clarity.js',
+  'clarity.ms',
+  'paddle.js',
+  'cdn.paddle.com',
+  'zaraz',
+  'cloudflareinsights',
+];
+
+function isThirdPartyError(err) {
+  const haystack = `${err?.message || ''}\n${err?.stack || ''}`;
+  return THIRD_PARTY_ERROR_SOURCES.some((src) => haystack.includes(src));
+}
+
+const HOME_VIEW = '[data-testid="home-view"]';
+const EDITOR_CONTENT = '[data-testid="dsl-editor"] .cm-content';
+
+/**
+ * Navigate to the HUB (HomeView library) with a CLEAN local slate, so its
+ * empty-state renders the `home-empty-templates` "Browse templates" button.
+ * Inlined here (per the no-shared-edit rule); mirrors library.spec.js gotoFresh
+ * but lands on the hub instead of the editor — we want the empty library state.
+ */
+async function gotoHubFresh(page) {
+  await suppressOneTimeModals(page); // keep onboarding/pledge from trapping focus
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  // Full navigation to the opt-in hub URL; useItems re-reads the (now empty) index.
+  await page.goto('/?view=diagrams');
+  await expect(page.locator(HOME_VIEW)).toBeVisible({ timeout: 15_000 });
+}
+
+/** Open the CreateNewModal picker via the hub's empty-state "Browse templates". */
+async function openPicker(page) {
+  const browse = page.locator('[data-testid="home-empty-templates"]');
+  await expect(browse).toBeVisible();
+  await browse.click();
+  const modal = page.locator('[data-testid="create-new-modal"]');
+  await expect(modal).toBeVisible();
+  return modal;
+}
+
+test.beforeEach(async ({ page }) => {
+  page.on('pageerror', (err) => {
+    if (isThirdPartyError(err)) return;
+    throw err;
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TPL-1: "Browse templates" opens the full CreateNewModal picker grid.
+// ──────────────────────────────────────────────────────────────────────────────
+test('TPL-1: "Browse templates" opens the full template picker grid', async ({
+  page,
+}) => {
+  await gotoHubFresh(page);
+  const modal = await openPicker(page);
+
+  // The picker is the full grid: a Blank card, the two labelled sections
+  // (Start / Styles), and every real template card. Assert the grid is fully
+  // populated — not a partial/empty modal.
+  await expect(modal).toContainText('Start');
+  await expect(modal).toContainText('Styles');
+
+  await expect(page.locator('[data-testid="create-blank"]')).toBeVisible();
+  for (const id of ['basic', 'black-white', 'blue', 'starUMLTheme']) {
+    await expect(
+      page.locator(`[data-testid="create-template-${id}"]`),
+    ).toBeVisible();
+  }
+
+  // Every selectable card is a real <button> (the grid is interactive, not a
+  // static preview). Blank + 4 templates = 5 cards.
+  const cards = modal.locator(
+    'button[data-testid="create-blank"], button[data-testid^="create-template-"]',
+  );
+  await expect(cards).toHaveCount(5);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TPL-2: each card loads its template's DSL into the editor AND opens it.
+//
+// One sub-test per card (honors the explicit "EACH template card" scope). Each
+// re-opens the picker fresh, clicks the card, and asserts: the modal closes, the
+// URL gains ?id=<newId> (the item was created AND opened), and the editor surface
+// shows that template's DSL (a token unique enough to prove it's THIS template,
+// not the default starter). Blank asserts an EMPTY editor (no template DSL).
+// ──────────────────────────────────────────────────────────────────────────────
+const TEMPLATE_CASES = [
+  // [card testid, a token that appears in the editor after loading this template]
+  ['create-template-basic', 'A.method()'],
+  ['create-template-black-white', 'Client->SGW'],
+  ['create-template-blue', 'Client->SGW'],
+  ['create-template-starUMLTheme', 'A.do()'],
+];
+
+for (const [cardTestId, dslToken] of TEMPLATE_CASES) {
+  test(`TPL-2: selecting ${cardTestId} loads its DSL into the editor and opens it`, async ({
+    page,
+  }) => {
+    await gotoHubFresh(page);
+    await openPicker(page);
+
+    await page.locator(`[data-testid="${cardTestId}"]`).click();
+
+    // The picker closes on selection (choose() → onOpenChange(false)).
+    await expect(page.locator('[data-testid="create-new-modal"]')).toBeHidden();
+
+    // handleCreateAndOpen navigates to '/?id=<newId>' — the diagram is OPENED,
+    // not just created. Prove the editor surface is now showing.
+    const editor = page.locator(EDITOR_CONTENT);
+    await expect(editor).toBeVisible({ timeout: 15_000 });
+    await expect(page).toHaveURL(/[?&]id=/, { timeout: 15_000 });
+    // The hub library is gone (we left it for the editor).
+    await expect(page.locator(HOME_VIEW)).toHaveCount(0);
+
+    // The editor shows THIS template's DSL — a token unique enough to distinguish
+    // it from the default starter (which is 'Alice -> Bob: Hello').
+    await expect(editor).toContainText(dslToken, { timeout: 15_000 });
+    await expect(editor).not.toContainText('Alice -> Bob: Hello');
+  });
+}
+
+test('TPL-2: selecting Blank opens an empty editor (no template DSL)', async ({
+  page,
+}) => {
+  await gotoHubFresh(page);
+  await openPicker(page);
+
+  await page.locator('[data-testid="create-blank"]').click();
+
+  await expect(page.locator('[data-testid="create-new-modal"]')).toBeHidden();
+
+  // Blank also navigates to '/?id=<newId>' (blankTemplate() → handleCreateAndOpen)
+  // and opens the editor — but with EMPTY content (no fabricated DSL).
+  const editor = page.locator(EDITOR_CONTENT);
+  await expect(editor).toBeVisible({ timeout: 15_000 });
+  await expect(page).toHaveURL(/[?&]id=/, { timeout: 15_000 });
+  await expect(page.locator(HOME_VIEW)).toHaveCount(0);
+
+  // Blank carries no template DSL and is not the styled-template content.
+  await expect(editor).not.toContainText('A.method()');
+  await expect(editor).not.toContainText('Client->SGW');
+  await expect(editor).not.toContainText('A.do()');
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TPL-3: each card shows a styled schematic preview.
+//
+// The CreateNewModal paints a CSS schematic per card (CreateNewModal.tsx Thumb /
+// BlankThumb): two participant boxes joined by tinted message lines for templates,
+// a dashed "+" canvas for Blank. The thumbnails are aria-hidden decorations, so we
+// assert the schematic ELEMENT is present + visible inside each card, and that the
+// themed-template thumbs carry their per-template tint as an INLINE border-color
+// style (proving the preview is STYLED to the template, not a bare placeholder).
+// ──────────────────────────────────────────────────────────────────────────────
+test('TPL-3: each card shows a styled schematic preview', async ({ page }) => {
+  await gotoHubFresh(page);
+  const modal = await openPicker(page);
+
+  // Blank's preview is the dashed-border "+" canvas (BlankThumb): an aria-hidden
+  // decorative div inside the card, plus the visible "+" glyph.
+  const blankCard = modal.locator('[data-testid="create-blank"]');
+  const blankThumb = blankCard.locator('div[aria-hidden="true"]').first();
+  await expect(blankThumb).toBeVisible();
+  await expect(blankThumb).toContainText('+');
+
+  // Every themed template card shows the participant/message schematic, tinted to
+  // the template theme. THUMB_TINTS (CreateNewModal.tsx) sets each card's participant
+  // box border-color inline to the template's box tint — assert that specific color
+  // is present (proves the preview is STYLED per-template, not a generic stub).
+  const expectedBoxTint = {
+    basic: 'rgb(138, 147, 161)', // #8A93A1
+    'black-white': 'rgb(0, 0, 0)', // #000000
+    blue: 'rgb(47, 107, 255)', // #2F6BFF
+    starUMLTheme: 'rgb(227, 201, 143)', // #e3c98f
+  };
+
+  for (const [id, tint] of Object.entries(expectedBoxTint)) {
+    const card = modal.locator(`[data-testid="create-template-${id}"]`);
+    // The schematic container (aria-hidden Thumb) is present and visible.
+    const thumb = card.locator('div[aria-hidden="true"]').first();
+    await expect(thumb).toBeVisible();
+
+    // The two tinted participant boxes carry the template's box tint inline.
+    const tintedBoxes = card.locator(
+      `span[style*="border-color: ${tint}"], span[style*="borderColor: ${tint}"]`,
+    );
+    await expect(tintedBoxes.first()).toBeVisible();
+    // Two participant boxes per schematic (left + right).
+    await expect(tintedBoxes).toHaveCount(2);
+  }
+});


### PR DESCRIPTION
## Summary

Executes `e2e/E2E_GAP_TEST_PLAN.md` (the gap plan): **57 new passing e2e tests** across 12 previously-uncovered app-level areas, authored + adversarially verified via multi-agent orchestration, plus a `test.fixme` scaffold for the infra-gated cases.

New specs: `preview`, `library-actions`, `multipage`, `settings`, `templates`, `export`, `modals-gap`, `css-editor`, `header`, `mobile`, `telemetry`, `connectivity`, and `cloud.fixme` (+ `EMULATOR_SETUP.md`).

## Validation
- Full new suite together (local dev): **57 passed / 46 skipped / 0 failed** (no cross-spec interference).
- Against **staging.zenuml.com**: **43 passed / 25 skipped / 0 failed** (local-only tests self-skip via `PW_BASE_URL`).
- Adversarial verify caught + fixed: a **false-green** (PRV-6, see below), a **flake** (LIB-4 Radix race), and 3 missing staging-gate skips (MOD-1/7a/7b).

## Honest `fixme`s (product gaps the tests surfaced — not dodges)
- **PRV-6**: `settings.autoPreview` is never wired to `PreviewFrame` → the auto-preview toggle is a dead control. Test documents the bug; flip to `test` once wired.
- **EXP-1/2**: no PNG/SVG export UI exists (`getPng()` handle has zero callers).
- **SET-4**: indent-size setting not connected to CodeMirror's `indentUnit`.
- **HDR-2**: title input has no Escape-to-revert.
- Auth/cloud-gated: HDR-3/4/6, CSS-5/6, SET-7, and the 35 `cloud.fixme` stubs (unlock via `EMULATOR_SETUP.md`).

## Scope
- `e2e/` only — no product code, no shared helpers, no existing specs modified.